### PR TITLE
fix(codemod): support aliased act() import

### DIFF
--- a/packages/codemods/react/19/replace-act-import/__testfixtures__/aliased-import.input.js
+++ b/packages/codemods/react/19/replace-act-import/__testfixtures__/aliased-import.input.js
@@ -1,0 +1,3 @@
+import { act as reactAct } from "react-dom/test-utils";
+
+reactAct();

--- a/packages/codemods/react/19/replace-act-import/__testfixtures__/aliased-import.output.js
+++ b/packages/codemods/react/19/replace-act-import/__testfixtures__/aliased-import.output.js
@@ -1,0 +1,3 @@
+import { act as reactAct } from "react";
+
+reactAct();

--- a/packages/codemods/react/19/replace-act-import/src/index.ts
+++ b/packages/codemods/react/19/replace-act-import/src/index.ts
@@ -94,10 +94,12 @@ export default function transform(
       specifiers: [{ type: "ImportSpecifier", imported: { name: "act" } }],
     })
     .forEach((path) => {
-      const newImportSpecifier = j.importSpecifier(
-        j.identifier("act"),
-        j.identifier("act"),
-      );
+      const actSpecifiers =
+        path.node.specifiers?.filter(
+          (specifier) =>
+            j.ImportSpecifier.check(specifier) &&
+            specifier.imported.name === "act",
+        ) ?? [];
 
       const existingReactImportCollection = root.find(j.ImportDeclaration, {
         source: { value: "react" },
@@ -111,13 +113,13 @@ export default function transform(
         existingReactImportCollection
           .paths()
           .at(0)
-          ?.node.specifiers?.push(newImportSpecifier);
+          ?.node.specifiers?.push(...actSpecifiers);
 
         path.prune();
         isDirty = true;
       } else {
         const newImportDeclaration = j.importDeclaration(
-          [newImportSpecifier],
+          actSpecifiers,
           j.literal("react"),
         );
 

--- a/packages/codemods/react/19/replace-act-import/test/test.ts
+++ b/packages/codemods/react/19/replace-act-import/test/test.ts
@@ -215,4 +215,29 @@ describe("react/19/replace-act-import: TestUtils.act -> React.act", () => {
       OUTPUT.replace(/\W/gm, ""),
     );
   });
+
+  it("should preserve aliased import specifier name", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "__testfixtures__/aliased-import.input.js"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(__dirname, "..", "__testfixtures__/aliased-import.output.js"),
+      "utf-8",
+    );
+
+    const fileInfo: FileInfo = {
+      path: "index.ts",
+      source: INPUT,
+    };
+
+    const actualOutput = transform(fileInfo, buildApi("js"), {
+      quote: "single",
+    });
+
+    assert.deepEqual(
+      actualOutput?.replace(/\W/gm, ""),
+      OUTPUT.replace(/\W/gm, ""),
+    );
+  });
 });


### PR DESCRIPTION
#### 📚 Description
This fixes an edge cast that we found in our codebase where the `act` named import was being aliased.

```diff
-import { ComponentType, ReactNode } from 'react';
-import { act as domAct } from 'react-dom/test-utils';
+import { ComponentType, ReactNode, act } from 'react';
```

The fix is to copy over all `act` specifiers instead of assuming that the new specifier is not aliased. I understand that it's impossible to handle all edge cases but this one _seems_ straightforward. As an alternative you could check that `local.name == 'act'` and skip transforming the import. That would prevent introducing broken code but limit the capabilities of the codemod.

#### 🧪 Test Plan
Added a unit test. 

#### 📄 Documentation to Update
N/A