### PR TITLE
fix(codemod): improve replace-string-ref accuracy

### DIFF
--- a/packages/codemods/react/19/replace-string-ref/__testfixtures__/class-component-custom-import-names.output.tsx
+++ b/packages/codemods/react/19/replace-string-ref/__testfixtures__/class-component-custom-import-names.output.tsx
@@ -5,7 +5,11 @@ class C extends React1.Component {
     return (
       <div
         ref={(ref) => {
-          this.refs.refName = ref;
+          if(ref === null) {
+            delete this.refs.refName;
+          } else {
+            this.refs.refName = ref;
+          }
         }}
       />
     );
@@ -17,7 +21,11 @@ class C1 extends PureComponent1 {
     return (
       <div
         ref={(ref) => {
-          this.refs.refName = ref;
+          if(ref === null) {
+            delete this.refs.refName;
+          } else {
+            this.refs.refName = ref;
+          }
         }}
       />
     );

--- a/packages/codemods/react/19/replace-string-ref/__testfixtures__/class-component-default-import.output.tsx
+++ b/packages/codemods/react/19/replace-string-ref/__testfixtures__/class-component-default-import.output.tsx
@@ -5,7 +5,11 @@ class C extends React.Component {
     return (
       <div
         ref={(ref) => {
-          this.refs.refName = ref;
+          if(ref === null) {
+            delete this.refs.refName;
+          } else {
+            this.refs.refName = ref;
+          }
         }}
       />
     );
@@ -17,7 +21,11 @@ class C1 extends React.PureComponent {
     return (
       <div
         ref={(ref) => {
-          this.refs.refName = ref;
+          if(ref === null) {
+            delete this.refs.refName;
+          } else {
+            this.refs.refName = ref;
+          }
         }}
       />
     );

--- a/packages/codemods/react/19/replace-string-ref/__testfixtures__/class-component-named-import.output.tsx
+++ b/packages/codemods/react/19/replace-string-ref/__testfixtures__/class-component-named-import.output.tsx
@@ -5,7 +5,11 @@ class C extends Component {
     return (
       <div
         ref={(ref) => {
-          this.refs.refName = ref;
+          if(ref === null) {
+            delete this.refs.refName;
+          } else {
+            this.refs.refName = ref;
+          }
         }}
       />
     );
@@ -17,7 +21,11 @@ class C1 extends PureComponent {
     return (
       <div
         ref={(ref) => {
-          this.refs.refName = ref;
+          if(ref === null) {
+            delete this.refs.refName;
+          } else {
+            this.refs.refName = ref;
+          }
         }}
       />
     );

--- a/packages/codemods/react/19/replace-string-ref/src/index.ts
+++ b/packages/codemods/react/19/replace-string-ref/src/index.ts
@@ -9,16 +9,13 @@ const buildCallbackRef = (j: JSCodeshift, refName: string) =>
       j.arrowFunctionExpression(
         [j.jsxIdentifier("ref")],
         j.blockStatement([
-          j.expressionStatement(
-            j.assignmentExpression(
-              "=",
-              j.memberExpression(
-                j.memberExpression(j.thisExpression(), j.identifier("refs")),
-                j.identifier(refName),
-              ),
-              j.identifier("ref"),
-            ),
-          ),
+          j.template.statement`
+            if (ref === null) {
+              delete this.refs.${j.identifier(refName)};
+            } else {
+              this.refs.${j.identifier(refName)} = ref;
+            }
+        `,
         ]),
       ),
     ),


### PR DESCRIPTION
#### 📚 Description

We ran the `replace-string-ref` codemod at scale and noticed a couple issues that could cause bugs.

```tsx
<div
  ref={(ref) => {
    this.refs.refName = ref;
  }}
/>;
```

This code above behaves differently than string refs because when the div in unmounted `this.refs.refName` is set to `null` instwead of the `refName` property being deleted. This can cause issues if you have logic in your code that relies on `typeof this.ref.refName`.

My first thought was to do `this.refs.refName = ref ?? undefined` but you can still run into issues if your code relies on stuff like `'refName' in this.refs`, `Object.keys(this.refs).length`, etc. 

I think some of these scenarios are unlikely so feel free to close this but I just wanted to call out this gotcha. It also might help to confirm with somebody from the React team if this is truly a more accurate replacement. 

A bonus with this change is that you no longer run into the TypeScript error:

```
Type 'HTMLDivElement | null' is not assignable to type 'ReactInstance'.
  Type 'null' is not assignable to type 'ReactInstance'.
```

#### 🧪 Test Plan

Added unit test