### PR TITLE
feat(cli/posthog): add events for jssg local and workflow local runs, and cli panics and add disable analytics feature [CDMD-4429] [CDMD-4423]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,8 +911,10 @@ name = "codemod-telemetry"
 version = "1.0.2"
 dependencies = [
  "async-trait",
+ "chrono",
  "posthog-rs",
  "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ name = "butterflow-core"
 version = "1.0.2"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "butterflow-models",
  "butterflow-runners",
  "butterflow-scheduler",
@@ -536,6 +537,7 @@ dependencies = [
  "futures-util",
  "ignore",
  "log",
+ "rand 0.9.2",
  "rayon",
  "regex",
  "reqwest 0.12.15",
@@ -3859,9 +3861,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -6625,7 +6627,7 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "wasm-bindgen",
 ]

--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -163,6 +163,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     let seconds = started.elapsed().as_millis() as f64 / 1000.0;
     println!("✨ Done in {seconds:.3}s");
 
+    // Generate a 20-byte execution ID (160 bits of entropy for collision resistance)
     let execution_id: [u8; 20] = rand::thread_rng().gen();
     let execution_id = base64::Engine::encode(
         &base64::engine::general_purpose::URL_SAFE_NO_PAD,

--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -170,8 +170,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     );
     let cli_version = env!("CARGO_PKG_VERSION");
 
-    let telemetry_sender = telemetry.lock().await;
-    telemetry_sender
+    telemetry
         .send_event(
             BaseEvent {
                 kind: "localJssgExecuted".to_string(),

--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -208,8 +208,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
 
     let cli_version = env!("CARGO_PKG_VERSION");
 
-    let telemetry_sender = telemetry.lock().await;
-    telemetry_sender
+    telemetry
         .send_event(
             BaseEvent {
                 kind: "codemodPublished".to_string(),

--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -17,7 +17,7 @@ use tempfile::TempDir;
 use walkdir::WalkDir;
 
 use crate::auth::TokenStorage;
-use crate::TelemetrySenderMutex;
+use crate::{TelemetrySenderMutex, CLI_VERSION};
 use codemod_telemetry::send_event::BaseEvent;
 
 #[derive(Args, Debug)]
@@ -206,8 +206,6 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         return Err(anyhow!("Failed to publish package"));
     }
 
-    let cli_version = env!("CARGO_PKG_VERSION");
-
     telemetry
         .send_event(
             BaseEvent {
@@ -215,7 +213,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
                 properties: HashMap::from([
                     ("codemodName".to_string(), manifest.name.clone()),
                     ("version".to_string(), manifest.version.clone()),
-                    ("cliVersion".to_string(), cli_version.to_string()),
+                    ("cliVersion".to_string(), CLI_VERSION.to_string()),
                     ("os".to_string(), std::env::consts::OS.to_string()),
                     ("arch".to_string(), std::env::consts::ARCH.to_string()),
                 ]),

--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -17,7 +17,8 @@ use tempfile::TempDir;
 use walkdir::WalkDir;
 
 use crate::auth::TokenStorage;
-use codemod_telemetry::send_event::{BaseEvent, TelemetrySender};
+use crate::TelemetrySenderMutex;
+use codemod_telemetry::send_event::BaseEvent;
 
 #[derive(Args, Debug)]
 pub struct Command {
@@ -125,7 +126,7 @@ struct PublishedPackage {
     published_at: String,
 }
 
-pub async fn handler(args: &Command, telemetry: &dyn TelemetrySender) -> Result<()> {
+pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<()> {
     let package_path = args
         .path
         .as_ref()
@@ -207,7 +208,8 @@ pub async fn handler(args: &Command, telemetry: &dyn TelemetrySender) -> Result<
 
     let cli_version = env!("CARGO_PKG_VERSION");
 
-    let _ = telemetry
+    let telemetry_sender = telemetry.lock().await;
+    telemetry_sender
         .send_event(
             BaseEvent {
                 kind: "codemodPublished".to_string(),

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -144,6 +144,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     println!("❌ Files with errors: {files_with_errors}");
 
     let cli_version = env!("CARGO_PKG_VERSION");
+    // Generate a 20-byte execution ID (160 bits of entropy for collision resistance)
     let execution_id: [u8; 20] = rand::thread_rng().gen();
     let execution_id = base64::Engine::encode(
         &base64::engine::general_purpose::URL_SAFE_NO_PAD,

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -2,14 +2,15 @@ use crate::engine::{create_engine, create_registry_client};
 use crate::progress_bar::download_progress_bar;
 use crate::workflow_runner::run_workflow;
 use crate::TelemetrySenderMutex;
+use crate::CLI_VERSION;
 use anyhow::{Context, Result};
 use butterflow_core::registry::RegistryError;
+use butterflow_core::utils::generate_execution_id;
 use butterflow_core::utils::parse_params;
 use clap::Args;
 use codemod_telemetry::send_event::BaseEvent;
 use console::style;
 use log::info;
-use rand::Rng;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
@@ -115,14 +116,13 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
 
     run_workflow(&engine, config).await?;
 
-    let cli_version = env!("CARGO_PKG_VERSION");
     telemetry
         .send_event(
             BaseEvent {
                 kind: "failedToExecuteCommand".to_string(),
                 properties: HashMap::from([
                     ("codemodName".to_string(), args.package.clone()),
-                    ("cliVersion".to_string(), cli_version.to_string()),
+                    ("cliVersion".to_string(), CLI_VERSION.to_string()),
                     (
                         "commandName".to_string(),
                         "codemod.executeCodemod".to_string(),
@@ -143,13 +143,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     println!("✅ Unmodified files: {files_unmodified}");
     println!("❌ Files with errors: {files_with_errors}");
 
-    let cli_version = env!("CARGO_PKG_VERSION");
-    // Generate a 20-byte execution ID (160 bits of entropy for collision resistance)
-    let execution_id: [u8; 20] = rand::thread_rng().gen();
-    let execution_id = base64::Engine::encode(
-        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
-        execution_id,
-    );
+    let execution_id = generate_execution_id();
 
     telemetry
         .send_event(
@@ -159,7 +153,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
                     ("codemodName".to_string(), args.package.clone()),
                     ("executionId".to_string(), execution_id.clone()),
                     ("fileCount".to_string(), files_modified.to_string()),
-                    ("cliVersion".to_string(), cli_version.to_string()),
+                    ("cliVersion".to_string(), CLI_VERSION.to_string()),
                     ("os".to_string(), std::env::consts::OS.to_string()),
                     ("arch".to_string(), std::env::consts::ARCH.to_string()),
                 ]),

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -116,8 +116,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     run_workflow(&engine, config).await?;
 
     let cli_version = env!("CARGO_PKG_VERSION");
-    let telemetry_sender = telemetry.lock().await;
-    telemetry_sender
+    telemetry
         .send_event(
             BaseEvent {
                 kind: "failedToExecuteCommand".to_string(),
@@ -151,7 +150,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         execution_id,
     );
 
-    telemetry_sender
+    telemetry
         .send_event(
             BaseEvent {
                 kind: "codemodExecuted".to_string(),

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -65,8 +65,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         execution_id,
     );
     let cli_version = env!("CARGO_PKG_VERSION");
-    let telemetry_sender = telemetry.lock().await;
-    telemetry_sender
+    telemetry
         .send_event(
             BaseEvent {
                 kind: "localWorkflowExecuted".to_string(),

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -59,6 +59,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     // Run workflow using the extracted workflow runner
     let (_, seconds) = run_workflow(&engine, config).await?;
 
+    // Generate a 20-byte execution ID (160 bits of entropy for collision resistance)
     let execution_id: [u8; 20] = rand::thread_rng().gen();
     let execution_id = base64::Engine::encode(
         &base64::engine::general_purpose::URL_SAFE_NO_PAD,

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::TelemetrySenderMutex;
+use crate::{TelemetrySenderMutex, CLI_VERSION};
 use anyhow::{Context, Result};
 use butterflow_core::utils;
+use butterflow_core::utils::generate_execution_id;
 use clap::Args;
 use codemod_telemetry::send_event::BaseEvent;
-use rand::Rng;
 
 use crate::engine::create_engine;
 use crate::workflow_runner::{resolve_workflow_source, run_workflow};
@@ -60,22 +60,16 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     let (_, seconds) = run_workflow(&engine, config).await?;
 
     // Generate a 20-byte execution ID (160 bits of entropy for collision resistance)
-    let execution_id: [u8; 20] = rand::thread_rng().gen();
-    let execution_id = base64::Engine::encode(
-        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
-        execution_id,
-    );
-    let cli_version = env!("CARGO_PKG_VERSION");
     telemetry
         .send_event(
             BaseEvent {
                 kind: "localWorkflowExecuted".to_string(),
                 properties: HashMap::from([
-                    ("executionId".to_string(), execution_id.clone()),
+                    ("executionId".to_string(), generate_execution_id()),
                     ("runTimeSeconds".to_string(), seconds.to_string()),
                     ("dirtyRun".to_string(), args.allow_dirty.to_string()),
                     ("dryRun".to_string(), args.dry_run.to_string()),
-                    ("cliVersion".to_string(), cli_version.to_string()),
+                    ("cliVersion".to_string(), CLI_VERSION.to_string()),
                     ("os".to_string(), std::env::consts::OS.to_string()),
                     ("arch".to_string(), std::env::consts::ARCH.to_string()),
                 ]),

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use butterflow_core::utils;
 use clap::Args;
+use codemod_telemetry::send_event::{BaseEvent, TelemetrySender};
+use rand::Rng;
 
 use crate::engine::create_engine;
 use crate::workflow_runner::{resolve_workflow_source, run_workflow};
@@ -31,7 +34,7 @@ pub struct Command {
 }
 
 /// Run a workflow
-pub async fn handler(args: &Command) -> Result<()> {
+pub async fn handler(args: &Command, telemetry: &dyn TelemetrySender) -> Result<()> {
     // Resolve workflow file and bundle path
     let (workflow_file_path, _) = resolve_workflow_source(&args.workflow)?;
 
@@ -53,7 +56,31 @@ pub async fn handler(args: &Command) -> Result<()> {
     )?;
 
     // Run workflow using the extracted workflow runner
-    run_workflow(&engine, config).await?;
+    let (_, seconds) = run_workflow(&engine, config).await?;
+
+    let execution_id: [u8; 20] = rand::thread_rng().gen();
+    let execution_id = base64::Engine::encode(
+        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+        execution_id,
+    );
+    let cli_version = env!("CARGO_PKG_VERSION");
+    telemetry
+        .send_event(
+            BaseEvent {
+                kind: "localWorkflowExecuted".to_string(),
+                properties: HashMap::from([
+                    ("executionId".to_string(), execution_id.clone()),
+                    ("runTimeSeconds".to_string(), seconds.to_string()),
+                    ("dirtyRun".to_string(), args.allow_dirty.to_string()),
+                    ("dryRun".to_string(), args.dry_run.to_string()),
+                    ("cliVersion".to_string(), cli_version.to_string()),
+                    ("os".to_string(), std::env::consts::OS.to_string()),
+                    ("arch".to_string(), std::env::consts::ARCH.to_string()),
+                ]),
+            },
+            None,
+        )
+        .await;
 
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -286,7 +286,13 @@ async fn main() -> Result<()> {
         .join()
         .unwrap();
 
-        std::process::exit(1);
+        std::panic::resume_unwind(Box::new(
+            panic_info
+                .payload()
+                .downcast_ref::<String>()
+                .unwrap_or(&"Unknown panic".to_string())
+                .clone(),
+        ));
     }));
 
     match &cli.command {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -17,12 +17,14 @@ use codemod_telemetry::{
     send_null::NullSender,
 };
 
+pub const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[derive(Parser)]
 #[command(name = "codemod")]
 #[command(
     about = "A self-hostable workflow engine for code transformations",
     long_about = "\x1b[32m      __                  __                                    __         \x1b[0m\n\x1b[32m     / /                 /\\ \\                                  /\\ \\        \x1b[0m\n\x1b[32m    / /   ___     ___    \\_\\ \\      __     ___ ___      ___    \\_\\ \\       \x1b[0m\n\x1b[32m   / /   /'___\\  / __`\\  /'_` \\   /'__`\\ /' __` __`\\   / __`\\  /'_` \\      \x1b[0m\n\x1b[32m  / /   /\\ \\__/ /\\ \\L\\ \\/\\ \\L\\ \\ /\\  __/ /\\ \\/\\ \\/\\ \\ /\\ \\L\\ \\/\\ \\L\\ \\  __ \x1b[0m\n\x1b[32m /_/    \\ \\____\\\\ \\____/\\ \\___,_\\\\ \\____\\\\ \\_\\ \\_\\ \\_\\\\ \\____/\\ \\___,_\\/\\_\\\x1b[0m\n\x1b[32m/_/      \\/____/ \\/___/  \\/__,_ / \\/____/ \\/_/\\/_/\\/_/ \\/___/  \\/__,_ /\\/_/\x1b[0m\n\x1b[32m                                                                           \x1b[0m\n\x1b[32m                                                                           \x1b[0m\n\nA self-hostable workflow engine for code transformations",
-    version = env!("CARGO_PKG_VERSION")
+    version = CLI_VERSION
 )]
 struct Cli {
     #[command(subcommand)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -227,7 +227,7 @@ async fn main() -> Result<()> {
     match &cli.command {
         Some(Commands::Workflow(args)) => match &args.command {
             WorkflowCommands::Run(args) => {
-                commands::workflow::run::handler(args).await?;
+                commands::workflow::run::handler(args, telemetry_sender.as_ref()).await?;
             }
             WorkflowCommands::Resume(args) => {
                 commands::workflow::resume::handler(args).await?;
@@ -250,7 +250,7 @@ async fn main() -> Result<()> {
                 args.clone().run().await?;
             }
             JssgCommands::Run(args) => {
-                commands::jssg::run::handler(args).await?;
+                commands::jssg::run::handler(args, telemetry_sender.as_ref()).await?;
             }
             JssgCommands::Test(args) => {
                 commands::jssg::test::handler(args).await?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -38,6 +38,10 @@ struct Cli {
 
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
     trailing_args: Vec<String>,
+
+    /// Disable telemetry
+    #[arg(long, short)]
+    disable_analytics: bool,
 }
 
 #[derive(Subcommand)]
@@ -203,6 +207,10 @@ async fn main() -> Result<()> {
         std::env::set_var("RUST_LOG", "debug");
     } else {
         std::env::set_var("RUST_LOG", "info");
+    }
+
+    if cli.disable_analytics {
+        std::env::set_var("DISABLE_ANALYTICS", "true");
     }
 
     let telemetry_sender: Arc<

--- a/crates/cli/src/workflow_runner.rs
+++ b/crates/cli/src/workflow_runner.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 /// Run a workflow with the given configuration
-pub async fn run_workflow(engine: &Engine, config: WorkflowRunConfig) -> Result<String> {
+pub async fn run_workflow(engine: &Engine, config: WorkflowRunConfig) -> Result<(String, f64)> {
     // Parse workflow file
     let workflow = utils::parse_workflow_file(engine.get_workflow_file_path()).context(format!(
         "Failed to parse workflow file: {}",
@@ -32,7 +32,7 @@ pub async fn run_workflow(engine: &Engine, config: WorkflowRunConfig) -> Result<
     let seconds = started.elapsed().as_millis() as f64 / 1000.0;
     println!("✨ Done in {seconds:.3}s");
 
-    Ok(workflow_run_id.to_string())
+    Ok((workflow_run_id.to_string(), seconds))
 }
 
 /// Wait for workflow to complete or pause

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -35,6 +35,8 @@ ignore = { workspace = true }
 bytes = "1.10.1"
 futures-util = "0.3.31"
 rayon = "1.10"
+base64 = "0.22.1"
+rand = "0.9.2"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -1,3 +1,4 @@
+use rand::Rng;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -225,4 +226,12 @@ pub fn get_cache_dir() -> Result<PathBuf> {
         .ok_or_else(|| Error::Other("Could not find home directory".to_string()))?;
     let cache_dir = home_dir.join("codemod").join("cache").join("packages");
     Ok(cache_dir)
+}
+
+pub fn generate_execution_id() -> String {
+    let execution_id: [u8; 20] = rand::rng().random();
+    base64::Engine::encode(
+        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+        execution_id,
+    )
 }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -12,5 +12,7 @@ build = "build.rs"
 
 [dependencies]
 async-trait.workspace = true
+chrono.workspace = true
 posthog-rs = "0.3.7"
 serde.workspace = true
+tokio.workspace = true

--- a/crates/telemetry/src/send_null.rs
+++ b/crates/telemetry/src/send_null.rs
@@ -12,4 +12,7 @@ impl TelemetrySender for NullSender {
     ) {
         // Do nothing
     }
+    async fn initialize_panic_telemetry(&self) {
+        // Do nothing
+    }
 }


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org
-->

#### 📚 Description
This PR adds new PostHog tracking events to improve visibility into usage and add disable analytics argument:
- **jssg** runs local jssg now trigger a PostHog event.
- **workflos** send PostHog events when workflow local run.
- **CLI panics** send PostHog events with details when CLI panicked

#### 🧪 Test Plan
- Verified locally that jssg and workflow runs trigger PostHog events.  
- Simulated a CLI panic and confirmed the event was sent.  

