### PR TITLE
fix(testing-utils): tests compare against the wrong expected result when there are fewer expected files than input files.

### DIFF
--- a/crates/testing-utils/src/fixtures.rs
+++ b/crates/testing-utils/src/fixtures.rs
@@ -111,8 +111,8 @@ impl TestSource {
                                 ),
                                 None => {
                                     // Expected file doesn't exist - create placeholder path for snapshot updates
-                                    let input_name = input_file.path.to_string_lossy().to_string();
-                                    let expected_path = input_name.replace("input", "expected");
+                                    let input_path = input_file.path.to_string_lossy().to_string();
+                                    let expected_path = input_path.replace("input", "expected");
                                     ("".to_string(), Some(PathBuf::from(expected_path)))
                                 }
                             };

--- a/crates/testing-utils/src/fixtures.rs
+++ b/crates/testing-utils/src/fixtures.rs
@@ -115,7 +115,7 @@ impl TestSource {
                                     {
                                         Ok(path) => Some(path),
                                         Err(e) => {
-                                            eprintln!("error contructing path: {}", e);
+                                            eprintln!("error constructing path: {}", e);
                                             None
                                         }
                                     };
@@ -430,15 +430,10 @@ fn build_expected_path(input_file_path: &Path) -> Result<PathBuf, Box<dyn std::e
             let expected_dir = if parent_dir.ends_with("input") {
                 parent_dir.with_file_name("expected")
             } else {
-                PathBuf::from(parent_dir)
+                parent_dir.to_path_buf()
             };
 
-            let expected_str = match expected_dir.to_str() {
-                Some(name) => name,
-                None => return Err("Invalid expected dir".into()),
-            };
-
-            PathBuf::from(expected_str).join(file_name)
+            expected_dir.join(file_name)
         }
     };
 

--- a/crates/testing-utils/src/fixtures.rs
+++ b/crates/testing-utils/src/fixtures.rs
@@ -401,7 +401,7 @@ fn collect_files_in_directory(
     Ok(files)
 }
 
-fn build_expected_path(input_file_path: &PathBuf) -> Result<PathBuf, Box<dyn std::error::Error>> {
+fn build_expected_path(input_file_path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let file_stem = match input_file_path.file_stem().and_then(|s| s.to_str()) {
         Some(stem) => stem,
         None => return Err("Invalid file stem".into()),


### PR DESCRIPTION
#### 📚 Description
In the current implementation, `input_tests` and `expected_tests` are stored in a `Vec`. To compare them, the code loops through `input_tests` and uses the index to fetch the corresponding item from `expected_tests`. The issue is that if `expected_tests` has fewer entries, the comparison ends up mismatching inputs and expected content after some.
Additionally, when using the `--update-snapshot flag`, it overwrites the wrong files.

What I this PR does is replace `Vec` by `HashMap` and use filename as `Key`

This PR also fixes a case where  files created by `--update-snapshot` were sometimes placed in the `./tests` folder instead of in ./tests/expected or `./tests/${test-case}`

---

I don’t have much experience with Rust, so if something can be improved or needs to be refactored, please let me know.