### PR TITLE
feat: add repository choice into init

### DIFF
--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -290,7 +290,18 @@ fn interactive_setup(project_name: &str, args: &Command) -> Result<ProjectConfig
     let git_repository_url = if let Some(url) = &args.git_repository_url {
         url.clone()
     } else {
-        Text::new("Git repository URL:").prompt()?
+        Text::new("Git repository URL:")
+            .with_validator(|input: &str| {
+                if input.is_empty() || input.starts_with("https://") || input.starts_with("git@") {
+                    Ok(inquire::validator::Validation::Valid)
+                } else {
+                    Ok(inquire::validator::Validation::Invalid(
+                        "Please enter a valid Git URL (must start with 'https://' or 'git@') or leave empty to skip."
+                            .into(),
+                    ))
+                }
+            })
+            .prompt()?
     };
 
     let description = if let Some(desc) = &args.description {
@@ -332,7 +343,11 @@ fn interactive_setup(project_name: &str, args: &Command) -> Result<ProjectConfig
         language,
         private,
         package_manager: args.package_manager.clone(),
-        git_repository_url: Some(git_repository_url),
+        git_repository_url: if git_repository_url.is_empty() {
+            None
+        } else {
+            Some(git_repository_url)
+        },
     })
 }
 

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -292,11 +292,11 @@ fn interactive_setup(project_name: &str, args: &Command) -> Result<ProjectConfig
     } else {
         Text::new("Git repository URL:")
             .with_validator(|input: &str| {
-                if input.is_empty() || input.starts_with("https://") || input.starts_with("git@") {
+                if input.is_empty() || input.starts_with("https://") {
                     Ok(inquire::validator::Validation::Valid)
                 } else {
                     Ok(inquire::validator::Validation::Invalid(
-                        "Please enter a valid Git URL (must start with 'https://' or 'git@') or leave empty to skip."
+                        "Please enter a valid Git URL (must start with 'https://') or leave empty to skip."
                             .into(),
                     ))
                 }

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -420,6 +420,12 @@ fn create_project(project_path: &Path, config: &ProjectConfig) -> Result<()> {
 }
 
 fn create_manifest(project_path: &Path, config: &ProjectConfig) -> Result<()> {
+    let repository_line = if let Some(url) = &config.git_repository_url {
+        format!("repository: \"{}\"", url)
+    } else {
+        String::new()
+    };
+
     let manifest_content = CODEMOD_TEMPLATE
         .replace("{name}", &config.name)
         .replace("{description}", &config.description)
@@ -434,10 +440,7 @@ fn create_manifest(project_path: &Path, config: &ProjectConfig) -> Result<()> {
             "{visibility}",
             if config.private { "private" } else { "public" },
         )
-        .replace(
-            "{repository}",
-            config.git_repository_url.as_deref().unwrap_or(""),
-        );
+        .replace("{repository}", &repository_line);
 
     fs::write(project_path.join("codemod.yaml"), manifest_content)?;
     Ok(())

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -137,6 +137,8 @@ static ROCKET: Emoji<'_, '_> = Emoji("🚀 ", "");
 static CHECKMARK: Emoji<'_, '_> = Emoji("✓ ", "");
 
 pub fn handler(args: &Command) -> Result<()> {
+    let git_repository_url = args.git_repository_url.clone();
+
     let (project_path, project_name, git_repository_url) = if args.no_interactive {
         let project_path = match args.path.clone() {
             Some(path) => path,
@@ -159,8 +161,6 @@ pub fn handler(args: &Command) -> Result<()> {
             }
         };
 
-        let git_repository_url = args.git_repository_url.clone();
-
         (project_path, project_name, git_repository_url)
     } else {
         // Interactive mode - ask for path if not provided
@@ -180,8 +180,6 @@ pub fn handler(args: &Command) -> Result<()> {
                 .unwrap_or("my-codemod")
                 .to_string()
         });
-
-        let git_repository_url = args.git_repository_url.clone();
 
         (project_path, project_name, git_repository_url)
     };

--- a/crates/cli/src/templates/codemod.yaml
+++ b/crates/cli/src/templates/codemod.yaml
@@ -6,7 +6,7 @@ description: "{description}"
 author: "{author}"
 license: "{license}"
 workflow: "workflow.yaml"
-repository: "{repository}"
+{repository}
 
 targets:
   languages: ["{language}"]

--- a/crates/cli/src/templates/codemod.yaml
+++ b/crates/cli/src/templates/codemod.yaml
@@ -6,6 +6,10 @@ description: "{description}"
 author: "{author}"
 license: "{license}"
 workflow: "workflow.yaml"
+repository: "{repository}"
+
+targets:
+  languages: ["{language}"]
 
 keywords: ["transformation", "migration"]
 


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
<!-- 
A summary of the change. Include relevant motivation and context.
For visual changes, add a snapshot or a Loom screencast to speed up reviews.
-->
Add git repository url prompt for init command