### PR TITLE
fix(cli): support DO_NOT_TRACK and ensure lazy telemetry initialization

### DIFF
--- a/crates/cli/npm/codemod
+++ b/crates/cli/npm/codemod
@@ -147,6 +147,7 @@ function shouldBootstrapLatestNoCommand(argv, env = process.env) {
 function spawnLatestCli({ env = process.env, platform = process.platform, spawnImpl = spawn }) {
   return spawnImpl(npmExecutable(platform), latestBootstrapArgs(), {
     stdio: "inherit",
+    shell: platform === "win32",
     env: {
       ...env,
       [CODEMOD_BOOTSTRAPPED_ENV]: "1",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -390,11 +390,15 @@ async fn main() -> Result<()> {
 
     let implicit_cli_params = Cli::try_parse_from(cli.trailing_args.clone());
 
-    if cli.disable_analytics
+    let is_analytics_disabled = cli.disable_analytics
+        || std::env::var("DO_NOT_TRACK").is_ok()
+        || std::env::var("DISABLE_ANALYTICS").is_ok()
         || implicit_cli_params
+            .as_ref()
             .map(|params| params.disable_analytics)
-            .unwrap_or(false)
-    {
+            .unwrap_or(false);
+
+    if is_analytics_disabled {
         std::env::set_var("DISABLE_ANALYTICS", "true");
     }
 

--- a/crates/telemetry/src/send_event.rs
+++ b/crates/telemetry/src/send_event.rs
@@ -41,7 +41,7 @@ pub trait TelemetrySender: Send + Sync + 'static {
 }
 
 pub struct PostHogSender {
-    client: Arc<posthog_rs::Client>,
+    client: OnceCell<Arc<posthog_rs::Client>>,
     options: TelemetrySenderOptions,
 }
 
@@ -49,11 +49,17 @@ pub const POSTHOG_API_KEY: &str = env!("POSTHOG_API_KEY");
 
 impl PostHogSender {
     pub async fn new(options: TelemetrySenderOptions) -> Self {
-        let client = posthog_rs::client(POSTHOG_API_KEY).await;
         Self {
-            client: Arc::new(client),
+            client: OnceCell::new(),
             options,
         }
+    }
+
+    async fn get_client(&self) -> Arc<posthog_rs::Client> {
+        self.client
+            .get_or_init(|| async { Arc::new(posthog_rs::client(POSTHOG_API_KEY).await) })
+            .await
+            .clone()
     }
 }
 
@@ -64,6 +70,7 @@ impl TelemetrySender for PostHogSender {
         event: BaseEvent,
         options_override: Option<PartialTelemetrySenderOptions>,
     ) {
+        let client = self.get_client().await;
         let distinct_id = options_override
             .as_ref()
             .and_then(|o| o.distinct_id.clone())
@@ -85,7 +92,7 @@ impl TelemetrySender for PostHogSender {
             }
         }
 
-        if let Err(e) = self.client.capture(posthog_event).await {
+        if let Err(e) = client.capture(posthog_event).await {
             eprintln!("Failed to send PostHog event: {e}");
         }
     }
@@ -95,8 +102,8 @@ impl TelemetrySender for PostHogSender {
             let _ = RUNTIME_HANDLE.set(handle);
         }
 
-        let client = self.client.clone();
         let options = self.options.clone();
+        let client_cell = self.client.clone();
 
         panic::set_hook(Box::new(move |panic_info| {
             let timestamp = Utc::now().format("%Y-%m-%d %H:%M:%S UTC").to_string();
@@ -121,10 +128,14 @@ impl TelemetrySender for PostHogSender {
             };
 
             if let Some(handle) = RUNTIME_HANDLE.get() {
-                let client = client.clone();
                 let options = options.clone();
+                let client_cell = client_cell.clone();
 
                 handle.spawn(async move {
+                    let client = client_cell
+                        .get_or_init(|| async { Arc::new(posthog_rs::client(POSTHOG_API_KEY).await) })
+                        .await;
+
                     let mut posthog_event = posthog_rs::Event::new(
                         format!("codemod.{}.cliPanic", options.cloud_role),
                         options.distinct_id.clone(),


### PR DESCRIPTION
## Summary
This PR addresses Issue #2058 (telemetry leak) and a Windows-specific \spawn EINVAL\ error.

### Changes
- **DO_NOT_TRACK Support**: Added support for the industry-standard \DO_NOT_TRACK\ environment variable in \main.rs\.
- **Lazy Telemetry Initialization**: Refactored \PostHogSender\ in \crates/telemetry\ to use \OnceCell\. The PostHog client is now only initialized on the first \send_event\ call, preventing early network handshakes even if analytics are enabled.
- **Windows Fix**: Added \shell: true\ to the CLI's \spawn\ implementation in \crates/cli/npm/codemod\ to resolve \EINVAL\ errors when executing \.cmd\ files on Windows.

Verified locally in a win32 environment.