### PR TITLE
Fix matrix master completion, workflow status rows, and TUI task visibility

### DIFF
--- a/crates/cli/src/commands/workflow/status.rs
+++ b/crates/cli/src/commands/workflow/status.rs
@@ -16,6 +16,10 @@ pub struct Command {
     /// Workflow run ID
     #[arg(short, long)]
     id: Uuid,
+
+    /// Print persisted workflow state as JSON (includes `shards` after evaluate-shards)
+    #[arg(long)]
+    show_state: bool,
 }
 
 #[derive(Tabled)]
@@ -104,6 +108,17 @@ pub async fn handler(args: &Command) -> Result<()> {
 
     println!("{table}");
 
+    if args.show_state {
+        let state = engine
+            .get_workflow_state(args.id)
+            .await
+            .context("Failed to load workflow state")?;
+        let pretty = serde_json::to_string_pretty(&serde_json::json!(state))
+            .context("Failed to serialize workflow state")?;
+        println!("Workflow state:");
+        println!("{pretty}");
+    }
+
     // Group tasks by node
     let mut tasks_by_node: HashMap<String, Vec<&Task>> = HashMap::new();
     for task in &tasks {
@@ -145,9 +160,9 @@ pub async fn handler(args: &Command) -> Result<()> {
                     })
                     .unwrap_or_else(|| "unknown".to_string());
                 tasks_rows.push(TaskRow {
-                    id: master_task.id.to_string(),
+                    id: task.id.to_string(),
                     node_id: node.id.clone(),
-                    status: format!("{:?}", master_task.status),
+                    status: format!("{:?}", task.status),
                     matrix_info,
                 });
             }

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -1193,9 +1193,8 @@ fn workflow_status_discriminant(status: WorkflowStatus) -> u8 {
 
 /// Order tasks like `workflow.yaml`: follow `workflow.nodes`, then matrix shards within a node.
 fn cmp_tasks_by_workflow_order(a: &Task, b: &Task, workflow: Option<&Workflow>) -> Ordering {
-    let pos = |task: &Task| {
-        workflow.and_then(|w| w.nodes.iter().position(|n| n.id == task.node_id))
-    };
+    let pos =
+        |task: &Task| workflow.and_then(|w| w.nodes.iter().position(|n| n.id == task.node_id));
     match (pos(a), pos(b)) {
         (Some(ia), Some(ib)) => ia
             .cmp(&ib)

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
@@ -6,7 +7,7 @@ use std::sync::mpsc::SyncSender;
 use anyhow::Result;
 use butterflow_core::ai_handoff::AgentOption;
 use butterflow_core::config::ShellCommandExecutionRequest;
-use butterflow_models::{Task, TaskStatus, WorkflowRun, WorkflowStatus};
+use butterflow_models::{Task, TaskStatus, Workflow, WorkflowRun, WorkflowStatus};
 use codemod_llrt_capabilities::types::LlrtSupportedModules;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::widgets::TableState;
@@ -15,6 +16,7 @@ use uuid::Uuid;
 use super::event::AppEvent;
 use super::screens::settings;
 use super::screens::StatusLine;
+use super::task_visibility::task_visible_in_list;
 
 pub const USE_BUILT_IN_AGENT: &str = "__use_built_in__";
 
@@ -367,7 +369,10 @@ impl App {
             } => {
                 self.workflow_runs = workflow_runs;
                 self.current_workflow_run = current_workflow_run;
-                sort_tasks(&mut tasks);
+                sort_tasks(
+                    &mut tasks,
+                    self.current_workflow_run.as_ref().map(|r| &r.workflow),
+                );
                 self.tasks = tasks;
                 self.sync_task_selection();
 
@@ -815,7 +820,7 @@ impl App {
         let visible_task_ids: Vec<Uuid> = self
             .tasks
             .iter()
-            .filter(|task| !task.is_master)
+            .filter(|task| task_visible_in_list(task, &self.tasks))
             .map(|task| task.id)
             .collect();
         let len = visible_task_ids.len();
@@ -893,14 +898,17 @@ impl App {
     }
 
     fn visible_tasks(&self) -> Vec<&Task> {
-        self.tasks.iter().filter(|task| !task.is_master).collect()
+        self.tasks
+            .iter()
+            .filter(|task| task_visible_in_list(task, &self.tasks))
+            .collect()
     }
 
     fn sync_task_selection(&mut self) {
         let visible_task_ids: Vec<Uuid> = self
             .tasks
             .iter()
-            .filter(|task| !task.is_master)
+            .filter(|task| task_visible_in_list(task, &self.tasks))
             .map(|task| task.id)
             .collect();
 
@@ -1082,8 +1090,8 @@ impl App {
     }
 }
 
-fn sort_tasks(tasks: &mut [Task]) {
-    tasks.sort_by_key(task_sort_key);
+fn sort_tasks(tasks: &mut [Task], workflow: Option<&Workflow>) {
+    tasks.sort_by(|a, b| cmp_tasks_by_workflow_order(a, b, workflow));
 }
 
 fn hash_workflow_runs(hasher: &mut DefaultHasher, workflow_runs: &[WorkflowRun]) {
@@ -1183,8 +1191,24 @@ fn workflow_status_discriminant(status: WorkflowStatus) -> u8 {
     }
 }
 
-fn task_sort_key(task: &Task) -> (String, String, Uuid) {
-    (task.node_id.clone(), matrix_sort_key(task), task.id)
+/// Order tasks like `workflow.yaml`: follow `workflow.nodes`, then matrix shards within a node.
+fn cmp_tasks_by_workflow_order(a: &Task, b: &Task, workflow: Option<&Workflow>) -> Ordering {
+    let pos = |task: &Task| {
+        workflow.and_then(|w| w.nodes.iter().position(|n| n.id == task.node_id))
+    };
+    match (pos(a), pos(b)) {
+        (Some(ia), Some(ib)) => ia
+            .cmp(&ib)
+            .then_with(|| matrix_sort_key(a).cmp(&matrix_sort_key(b)))
+            .then_with(|| a.id.cmp(&b.id)),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => a
+            .node_id
+            .cmp(&b.node_id)
+            .then_with(|| matrix_sort_key(a).cmp(&matrix_sort_key(b)))
+            .then_with(|| a.id.cmp(&b.id)),
+    }
 }
 
 fn matrix_sort_key(task: &Task) -> String {

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -2,6 +2,8 @@ pub mod app;
 pub mod event;
 pub mod screens;
 
+mod task_visibility;
+
 use std::collections::{HashSet, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::sync::Arc;

--- a/crates/cli/src/tui/screens/task_list.rs
+++ b/crates/cli/src/tui/screens/task_list.rs
@@ -9,6 +9,7 @@ use ratatui::{
 };
 
 use crate::tui::app::LogView;
+use crate::tui::task_visibility::{awaiting_trigger_visible, failed_visible, task_visible_in_list};
 
 use super::{
     centered_rect, format_duration, key_hint, key_hint_colored, render_status_line,
@@ -47,7 +48,10 @@ pub fn render(
         Block::default().style(Style::default().bg(BODY_BG)),
         chunks[1],
     );
-    let visible_tasks: Vec<&Task> = tasks.iter().filter(|task| !task.is_master).collect();
+    let visible_tasks: Vec<&Task> = tasks
+        .iter()
+        .filter(|task| task_visible_in_list(task, tasks))
+        .collect();
 
     if visible_tasks.is_empty() {
         let y = content.y + content.height / 2;
@@ -103,7 +107,7 @@ fn collect_matrix_columns(tasks: &[&Task]) -> Vec<String> {
                 .map(|value| match value {
                     serde_json::Value::String(value) => value.len(),
                     other => other.to_string().len(),
-                } < 32)
+                } < 96)
                 .unwrap_or(true)
         })
     });
@@ -212,7 +216,7 @@ fn build_widths(tasks: &[&Task], matrix_columns: &[String]) -> Vec<Constraint> {
             .max()
             .unwrap_or(0);
         widths.push(Constraint::Length(
-            max_len.max(key.len()).min(32) as u16 + 2,
+            max_len.max(key.len()).min(96) as u16 + 2,
         ));
     }
     widths.push(Constraint::Length(10));
@@ -280,12 +284,8 @@ fn build_hint_groups(tasks: &[Task], log_view_open: bool) -> Vec<Vec<Span<'stati
         ];
     }
 
-    let has_awaiting = tasks
-        .iter()
-        .any(|task| task.status == TaskStatus::AwaitingTrigger && !task.is_master);
-    let has_failed = tasks
-        .iter()
-        .any(|task| task.status == TaskStatus::Failed && !task.is_master);
+    let has_awaiting = awaiting_trigger_visible(tasks);
+    let has_failed = failed_visible(tasks);
 
     let mut groups: Vec<Vec<Span<'static>>> = Vec::new();
     groups.push(key_hint("↑↓", "navigate"));

--- a/crates/cli/src/tui/task_visibility.rs
+++ b/crates/cli/src/tui/task_visibility.rs
@@ -1,0 +1,84 @@
+//! Which workflow tasks appear in the task list.
+//!
+//! Matrix nodes use a "master" task plus one task per matrix combination. The TUI
+//! historically hid all master tasks to avoid duplicate rows once child tasks exist.
+//! For `strategy.matrix.from_state`, only the master exists until state (e.g. shards)
+//! is written and the scheduler materializes child tasks — hiding the master made
+//! manual matrix nodes invisible until children appeared.
+
+use butterflow_models::{Task, TaskStatus};
+
+/// Whether `task` should be shown as a row in the workflow task list.
+pub(crate) fn task_visible_in_list(task: &Task, all_tasks: &[Task]) -> bool {
+    if !task.is_master {
+        return true;
+    }
+    let has_children = all_tasks
+        .iter()
+        .any(|t| t.master_task_id == Some(task.id));
+    !has_children
+}
+
+pub(crate) fn awaiting_trigger_visible(tasks: &[Task]) -> bool {
+    tasks.iter().any(|task| {
+        task.status == TaskStatus::AwaitingTrigger && task_visible_in_list(task, tasks)
+    })
+}
+
+pub(crate) fn failed_visible(tasks: &[Task]) -> bool {
+    tasks.iter().any(|task| {
+        task.status == TaskStatus::Failed && task_visible_in_list(task, tasks)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn base_task(
+        workflow_run_id: Uuid,
+        node_id: &str,
+        is_master: bool,
+        master_task_id: Option<Uuid>,
+    ) -> Task {
+        Task {
+            id: Uuid::new_v4(),
+            workflow_run_id,
+            node_id: node_id.to_string(),
+            status: TaskStatus::Blocked,
+            is_master,
+            master_task_id,
+            matrix_values: None,
+            started_at: Some(Utc::now()),
+            ended_at: None,
+            error: None,
+            logs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn non_master_always_visible() {
+        let run = Uuid::new_v4();
+        let t = base_task(run, "evaluate-shards", false, None);
+        assert!(task_visible_in_list(&t, &[t.clone()]));
+    }
+
+    #[test]
+    fn matrix_master_visible_until_children_exist() {
+        let run = Uuid::new_v4();
+        let master = base_task(run, "apply-transforms", true, None);
+        assert!(task_visible_in_list(&master, &[master.clone()]));
+
+        let child = {
+            let mut c = base_task(run, "apply-transforms", false, Some(master.id));
+            c.matrix_values = Some(
+                std::collections::HashMap::from([("name".to_string(), serde_json::json!("a"))]),
+            );
+            c
+        };
+        assert!(!task_visible_in_list(&master, &[master.clone(), child.clone()]));
+        assert!(task_visible_in_list(&child, &[master.clone(), child.clone()]));
+    }
+}

--- a/crates/cli/src/tui/task_visibility.rs
+++ b/crates/cli/src/tui/task_visibility.rs
@@ -13,22 +13,20 @@ pub(crate) fn task_visible_in_list(task: &Task, all_tasks: &[Task]) -> bool {
     if !task.is_master {
         return true;
     }
-    let has_children = all_tasks
-        .iter()
-        .any(|t| t.master_task_id == Some(task.id));
+    let has_children = all_tasks.iter().any(|t| t.master_task_id == Some(task.id));
     !has_children
 }
 
 pub(crate) fn awaiting_trigger_visible(tasks: &[Task]) -> bool {
-    tasks.iter().any(|task| {
-        task.status == TaskStatus::AwaitingTrigger && task_visible_in_list(task, tasks)
-    })
+    tasks
+        .iter()
+        .any(|task| task.status == TaskStatus::AwaitingTrigger && task_visible_in_list(task, tasks))
 }
 
 pub(crate) fn failed_visible(tasks: &[Task]) -> bool {
-    tasks.iter().any(|task| {
-        task.status == TaskStatus::Failed && task_visible_in_list(task, tasks)
-    })
+    tasks
+        .iter()
+        .any(|task| task.status == TaskStatus::Failed && task_visible_in_list(task, tasks))
 }
 
 #[cfg(test)]
@@ -62,23 +60,30 @@ mod tests {
     fn non_master_always_visible() {
         let run = Uuid::new_v4();
         let t = base_task(run, "evaluate-shards", false, None);
-        assert!(task_visible_in_list(&t, &[t.clone()]));
+        assert!(task_visible_in_list(&t, std::slice::from_ref(&t)));
     }
 
     #[test]
     fn matrix_master_visible_until_children_exist() {
         let run = Uuid::new_v4();
         let master = base_task(run, "apply-transforms", true, None);
-        assert!(task_visible_in_list(&master, &[master.clone()]));
+        assert!(task_visible_in_list(&master, std::slice::from_ref(&master)));
 
         let child = {
             let mut c = base_task(run, "apply-transforms", false, Some(master.id));
-            c.matrix_values = Some(
-                std::collections::HashMap::from([("name".to_string(), serde_json::json!("a"))]),
-            );
+            c.matrix_values = Some(std::collections::HashMap::from([(
+                "name".to_string(),
+                serde_json::json!("a"),
+            )]));
             c
         };
-        assert!(!task_visible_in_list(&master, &[master.clone(), child.clone()]));
-        assert!(task_visible_in_list(&child, &[master.clone(), child.clone()]));
+        assert!(!task_visible_in_list(
+            &master,
+            &[master.clone(), child.clone()]
+        ));
+        assert!(task_visible_in_list(
+            &child,
+            &[master.clone(), child.clone()]
+        ));
     }
 }

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -576,12 +576,7 @@ fn refresh_result_seeds_session_overrides_from_workflow_run_once() {
 fn refresh_orders_tasks_by_workflow_yaml_node_order() {
     let run_id = Uuid::new_v4();
     let mut app = App::new_for_run(false, None, run_id);
-    let add = task(
-        run_id,
-        "add-descriptions",
-        TaskStatus::Pending,
-        vec![],
-    );
+    let add = task(run_id, "add-descriptions", TaskStatus::Pending, vec![]);
     let evaluate = task(run_id, "evaluate-shards", TaskStatus::Pending, vec![]);
     let workflow = Workflow {
         version: "1".to_string(),

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -79,9 +79,18 @@ fn workflow_run(
     status: WorkflowStatus,
     capabilities: Option<HashSet<LlrtSupportedModules>>,
 ) -> WorkflowRun {
+    workflow_run_with_workflow(id, status, capabilities, empty_workflow())
+}
+
+fn workflow_run_with_workflow(
+    id: Uuid,
+    status: WorkflowStatus,
+    capabilities: Option<HashSet<LlrtSupportedModules>>,
+    workflow: Workflow,
+) -> WorkflowRun {
     WorkflowRun {
         id,
-        workflow: empty_workflow(),
+        workflow,
         status,
         params: HashMap::new(),
         tasks: vec![],
@@ -91,6 +100,24 @@ fn workflow_run(
         capabilities,
         name: Some("Example Workflow".to_string()),
         target_path: Some(Path::new("/tmp/example-target").to_path_buf()),
+    }
+}
+
+fn minimal_script_node(id: &str, name: &str) -> Node {
+    let step_id = format!("{id}-step");
+    Node {
+        id: id.to_string(),
+        name: name.to_string(),
+        description: None,
+        r#type: NodeType::Automatic,
+        depends_on: vec![],
+        trigger: None,
+        strategy: None,
+        runtime: direct_runtime(),
+        steps: vec![script_step(&step_id, name, "true".to_string())],
+        env: HashMap::new(),
+        branch_name: None,
+        pull_request: None,
     }
 }
 
@@ -543,6 +570,41 @@ fn refresh_result_seeds_session_overrides_from_workflow_run_once() {
         .capabilities
         .as_ref()
         .is_some_and(|set| set.contains(&LlrtSupportedModules::Fetch)));
+}
+
+#[test]
+fn refresh_orders_tasks_by_workflow_yaml_node_order() {
+    let run_id = Uuid::new_v4();
+    let mut app = App::new_for_run(false, None, run_id);
+    let add = task(
+        run_id,
+        "add-descriptions",
+        TaskStatus::Pending,
+        vec![],
+    );
+    let evaluate = task(run_id, "evaluate-shards", TaskStatus::Pending, vec![]);
+    let workflow = Workflow {
+        version: "1".to_string(),
+        state: None,
+        params: None,
+        templates: vec![],
+        nodes: vec![
+            minimal_script_node("evaluate-shards", "Evaluate"),
+            minimal_script_node("add-descriptions", "Add descriptions"),
+        ],
+    };
+    app.apply_effect_result(EffectResult::Refreshed {
+        workflow_runs: vec![],
+        current_workflow_run: Some(workflow_run_with_workflow(
+            run_id,
+            WorkflowStatus::Running,
+            None,
+            workflow,
+        )),
+        tasks: vec![add, evaluate],
+    });
+    assert_eq!(app.tasks[0].node_id, "evaluate-shards");
+    assert_eq!(app.tasks[1].node_id, "add-descriptions");
 }
 
 #[test]

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -76,7 +76,11 @@ use semantic_factory::LazySemanticProvider;
 /// True when every task for each `depends_on` node is [`TaskStatus::Completed`], matching
 /// [`Scheduler::find_runnable_tasks_internal`]. Used so matrix masters are not marked
 /// completed while dependency nodes (e.g. shard evaluation) are still running.
-fn workflow_node_dependencies_satisfied(workflow: &Workflow, tasks: &[Task], node_id: &str) -> bool {
+fn workflow_node_dependencies_satisfied(
+    workflow: &Workflow,
+    tasks: &[Task],
+    node_id: &str,
+) -> bool {
     let Some(node) = workflow.nodes.iter().find(|n| n.id == node_id) else {
         return false;
     };
@@ -85,10 +89,7 @@ fn workflow_node_dependencies_satisfied(workflow: &Workflow, tasks: &[Task], nod
         if dep_tasks.is_empty() {
             return false;
         }
-        if !dep_tasks
-            .iter()
-            .all(|t| t.status == TaskStatus::Completed)
-        {
+        if !dep_tasks.iter().all(|t| t.status == TaskStatus::Completed) {
             return false;
         }
     }

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -73,6 +73,28 @@ use codemod_sandbox::{
 use language_core::SemanticProvider;
 use semantic_factory::LazySemanticProvider;
 
+/// True when every task for each `depends_on` node is [`TaskStatus::Completed`], matching
+/// [`Scheduler::find_runnable_tasks_internal`]. Used so matrix masters are not marked
+/// completed while dependency nodes (e.g. shard evaluation) are still running.
+fn workflow_node_dependencies_satisfied(workflow: &Workflow, tasks: &[Task], node_id: &str) -> bool {
+    let Some(node) = workflow.nodes.iter().find(|n| n.id == node_id) else {
+        return false;
+    };
+    for dep_id in &node.depends_on {
+        let dep_tasks: Vec<&Task> = tasks.iter().filter(|t| t.node_id == *dep_id).collect();
+        if dep_tasks.is_empty() {
+            return false;
+        }
+        if !dep_tasks
+            .iter()
+            .all(|t| t.status == TaskStatus::Completed)
+        {
+            return false;
+        }
+    }
+    true
+}
+
 /// Guard that ensures task completion notification is sent even on panic/timeout
 struct TaskCleanupGuard {
     notify: Arc<Notify>,
@@ -1387,6 +1409,19 @@ impl Engine {
             .lock()
             .await
             .list_workflow_runs(limit)
+            .await
+    }
+
+    /// Persisted workflow state (e.g. `shards` written by shard steps). Stored on disk by the
+    /// local adapter under `<data_dir>/butterflow/state/<workflow_run_id>.json`.
+    pub async fn get_workflow_state(
+        &self,
+        workflow_run_id: Uuid,
+    ) -> Result<HashMap<String, serde_json::Value>> {
+        self.state_adapter
+            .lock()
+            .await
+            .get_state(workflow_run_id)
             .await
     }
 
@@ -4880,17 +4915,25 @@ impl Engine {
             .filter(|t| t.master_task_id == Some(master_task_id))
             .collect();
 
-        // If there are no child tasks (e.g., state was empty or cleared), the master should reflect that.
+        // If there are no child tasks: either shard state is not ready yet, or the matrix is
+        // genuinely empty. Do not complete the master while `depends_on` nodes are still
+        // running — otherwise the UI shows the matrix node "done" during shard evaluation.
         if child_tasks.is_empty() {
-            debug!("No child tasks found for master task {master_task_id}, setting status to Completed (or Pending if master just created).");
-            let final_status = if master_task.status == TaskStatus::Pending {
-                // If the master was just created and has no children yet (empty state)
-                // Keep it Pending until state potentially provides children.
-                // Or should it be Completed? Let's try Completed.
-                TaskStatus::Completed // Or Pending? Needs careful consideration. Let's assume Completed for empty state.
-            } else {
-                TaskStatus::Completed // If children existed and were removed, it's Completed.
-            };
+            let workflow_run = self.get_workflow_run(master_task.workflow_run_id).await?;
+            if !workflow_node_dependencies_satisfied(
+                &workflow_run.workflow,
+                &tasks,
+                &master_task.node_id,
+            ) {
+                debug!(
+                    "No child tasks for matrix master {master_task_id} (node {}); dependencies not finished — leaving status as {:?}",
+                    master_task.node_id, master_task.status
+                );
+                return Ok(());
+            }
+
+            debug!("No child tasks for master task {master_task_id} after dependencies satisfied; treating as empty matrix.");
+            let final_status = TaskStatus::Completed;
 
             let mut fields = HashMap::new();
             fields.insert(
@@ -5244,5 +5287,149 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("No progress observed"));
         assert!(message.contains("src/stalled.ts"));
+    }
+
+    /// Matrix master with `from_state` has no child tasks until state exists. While dependency
+    /// nodes are not fully completed, the master must not be marked completed (regression guard).
+    #[tokio::test]
+    async fn update_matrix_master_with_no_children_skips_completion_until_depends_on_complete() {
+        use butterflow_models::node::NodeType;
+        use butterflow_models::runtime::{Runtime, RuntimeType};
+        use butterflow_models::strategy::StrategyType;
+        use butterflow_models::{Step, WorkflowState};
+        use butterflow_state::mock_adapter::MockStateAdapter;
+
+        let workflow_run_id = Uuid::new_v4();
+        let workflow = Workflow {
+            version: "1".to_string(),
+            params: None,
+            state: Some(WorkflowState::default()),
+            templates: vec![],
+            nodes: vec![
+                Node {
+                    id: "node1".to_string(),
+                    name: "Node 1".to_string(),
+                    description: None,
+                    r#type: NodeType::Automatic,
+                    depends_on: vec![],
+                    trigger: None,
+                    strategy: None,
+                    runtime: Some(Runtime {
+                        r#type: RuntimeType::Direct,
+                        image: None,
+                        working_dir: None,
+                        user: None,
+                        network: None,
+                        options: None,
+                    }),
+                    steps: vec![Step {
+                        id: Some("step-1".to_string()),
+                        name: "Step 1".to_string(),
+                        action: StepAction::RunScript("true".to_string()),
+                        env: None,
+                        condition: None,
+                        commit: None,
+                    }],
+                    env: HashMap::new(),
+                    branch_name: None,
+                    pull_request: None,
+                },
+                Node {
+                    id: "node2".to_string(),
+                    name: "Node 2".to_string(),
+                    description: None,
+                    r#type: NodeType::Automatic,
+                    depends_on: vec!["node1".to_string()],
+                    trigger: None,
+                    strategy: Some(Strategy {
+                        r#type: StrategyType::Matrix,
+                        values: None,
+                        from_state: Some("files".to_string()),
+                    }),
+                    runtime: Some(Runtime {
+                        r#type: RuntimeType::Direct,
+                        image: None,
+                        working_dir: None,
+                        user: None,
+                        network: None,
+                        options: None,
+                    }),
+                    steps: vec![Step {
+                        id: Some("step-2".to_string()),
+                        name: "Step 1".to_string(),
+                        action: StepAction::RunScript("true".to_string()),
+                        env: None,
+                        condition: None,
+                        commit: None,
+                    }],
+                    env: HashMap::new(),
+                    branch_name: None,
+                    pull_request: None,
+                },
+            ],
+        };
+
+        let workflow_run = WorkflowRun {
+            id: workflow_run_id,
+            workflow,
+            status: WorkflowStatus::Running,
+            params: HashMap::new(),
+            tasks: vec![],
+            started_at: Utc::now(),
+            ended_at: None,
+            bundle_path: None,
+            capabilities: None,
+            name: None,
+            target_path: None,
+        };
+
+        let engine = Engine::with_state_adapter(
+            Box::new(MockStateAdapter::new()),
+            WorkflowRunConfig::default(),
+        );
+
+        engine
+            .state_adapter
+            .lock()
+            .await
+            .save_workflow_run(&workflow_run)
+            .await
+            .unwrap();
+
+        let node1_task = Task::new(workflow_run_id, "node1".to_string(), false);
+        let master_task = Task::new(workflow_run_id, "node2".to_string(), true);
+
+        engine
+            .state_adapter
+            .lock()
+            .await
+            .save_task(&node1_task)
+            .await
+            .unwrap();
+        engine
+            .state_adapter
+            .lock()
+            .await
+            .save_task(&master_task)
+            .await
+            .unwrap();
+
+        engine
+            .update_matrix_master_status(master_task.id)
+            .await
+            .unwrap();
+
+        let master_after = engine
+            .state_adapter
+            .lock()
+            .await
+            .get_task(master_task.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            master_after.status,
+            TaskStatus::Pending,
+            "master must stay non-terminal while dependency node tasks are not all completed"
+        );
     }
 }


### PR DESCRIPTION
## Summary

### What

- **Engine:** Do not mark a matrix **master** complete with **no children** while **`depends_on`** nodes still have non-completed tasks; expose **`get_workflow_state`** for debugging.
- **CLI:** `workflow status` shows **per-matrix-child** id/status (not the master's); add **`--show-state`** for persisted state JSON.
- **TUI:** Task **order** vs `workflow.yaml`, **master visibility** when only the master exists (`from_state`), wider **matrix** columns.

### Risk

Touches **high-impact** paths (workflow correctness, CLI table output, interactive UI). Failures would mostly show as wrong status/order in the UI/CLI; engine mistakes could misrepresent "done." Mitigated by a focused **engine unit test** on the matrix-master + **dependencies not satisfied** case.

### Validation

- `cargo test` (including the new engine test).
- Manual run on **debrrael codemod** — looks good.
