### PR TITLE
fix(jssg): decode legacy-encoded source files for analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,11 +715,13 @@ dependencies = [
  "butterflow-scheduler",
  "butterflow-state",
  "bytes",
+ "chardetng",
  "chrono",
  "codemod-ai",
  "codemod-llrt-capabilities",
  "codemod-sandbox",
  "dirs",
+ "encoding_rs",
  "flate2",
  "futures-util",
  "ignore",
@@ -966,6 +968,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,8 @@ tokio = { version = "1.36", features = ["full"] }
 uuid = { version = "1.6", features = ["v4", "serde"] }
 vfs = "0.12"
 walkdir = "2.4"
+encoding_rs = "0.8"
+chardetng = "0.1"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm_0_29"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 

--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -8,7 +8,7 @@ use crate::CLI_VERSION;
 use crate::{capabilities_security_callback::capabilities_security_callback, dirty_git_check};
 use anyhow::Result;
 use butterflow_core::diff::{generate_unified_diff, DiffConfig, DiffMetadata, FileDiff};
-use butterflow_core::file_ops::decode_source_bytes;
+use butterflow_core::file_ops::{decode_source_bytes, read_source_file};
 use butterflow_core::report::{convert_diffs, convert_metrics, ExecutionReport};
 use butterflow_core::utils::generate_execution_id;
 use butterflow_core::utils::parse_params;
@@ -190,8 +190,8 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
             let target_files: Vec<PathBuf> = config.collect_files();
             for file_path in &target_files {
                 if file_path.is_file() {
-                    if let Ok(content) = std::fs::read_to_string(file_path) {
-                        let _ = provider.notify_file_processed(file_path, &content);
+                    if let Ok(decoded) = read_source_file(file_path) {
+                        let _ = provider.notify_file_processed(file_path, &decoded.content);
                     }
                 }
             }
@@ -351,9 +351,10 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
                                 let original = if change_path == file_path {
                                     content.clone()
                                 } else {
-                                    tokio::fs::read_to_string(change_path)
-                                        .await
-                                        .unwrap_or_default()
+                                    match tokio::fs::read(change_path).await {
+                                        Ok(bytes) => decode_source_bytes(&bytes).content,
+                                        Err(_) => String::new(),
+                                    }
                                 };
                                 let diff = generate_unified_diff(
                                     change_path,

--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -8,6 +8,7 @@ use crate::CLI_VERSION;
 use crate::{capabilities_security_callback::capabilities_security_callback, dirty_git_check};
 use anyhow::Result;
 use butterflow_core::diff::{generate_unified_diff, DiffConfig, DiffMetadata, FileDiff};
+use butterflow_core::file_ops::decode_source_bytes;
 use butterflow_core::report::{convert_diffs, convert_metrics, ExecutionReport};
 use butterflow_core::utils::generate_execution_id;
 use butterflow_core::utils::parse_params;
@@ -235,9 +236,19 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         // Use a tokio runtime to handle the async execution within the sync callback
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            // Read file content
-            let content = match tokio::fs::read_to_string(&file_path).await {
-                Ok(content) => content,
+            // Read file content, decoding legacy encodings when needed.
+            let content = match tokio::fs::read(&file_path).await {
+                Ok(bytes) => {
+                    let decoded = decode_source_bytes(&bytes);
+                    if let Some(encoding) = decoded.decoded_from {
+                        warn!(
+                            "Decoded non-UTF-8 file {} as {} for analysis",
+                            file_path.display(),
+                            encoding
+                        );
+                    }
+                    decoded.content
+                }
                 Err(e) => {
                     warn!("Failed to read file {}: {}", file_path.display(), e);
                     return;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -45,6 +45,8 @@ language-core = { workspace = true }
 anyhow.workspace = true
 similar = "2.6.0"
 sha2 = "0.10"
+encoding_rs = { workspace = true }
+chardetng = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/core/src/file_ops.rs
+++ b/crates/core/src/file_ops.rs
@@ -121,4 +121,20 @@ mod tests {
         assert_eq!(decoded.content, "café");
         assert!(decoded.decoded_from.is_some());
     }
+
+    #[test]
+    fn decode_source_bytes_handles_utf16le_bom() {
+        // UTF-16LE BOM + "ab"
+        let decoded = decode_source_bytes(&[0xFF, 0xFE, b'a', 0, b'b', 0]);
+        assert_eq!(decoded.content, "ab");
+        assert_eq!(decoded.decoded_from, Some("UTF-16LE"));
+    }
+
+    #[test]
+    fn decode_source_bytes_handles_utf16be_bom() {
+        // UTF-16BE BOM + "ab"
+        let decoded = decode_source_bytes(&[0xFE, 0xFF, 0, b'a', 0, b'b']);
+        assert_eq!(decoded.content, "ab");
+        assert_eq!(decoded.decoded_from, Some("UTF-16BE"));
+    }
 }

--- a/crates/core/src/file_ops.rs
+++ b/crates/core/src/file_ops.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::sync::mpsc;
 
 /// File write operation for batched async I/O
@@ -7,6 +7,58 @@ pub struct FileWriteOperation {
     path: PathBuf,
     content: String,
     sender: tokio::sync::oneshot::Sender<std::io::Result<()>>,
+}
+
+/// Result of reading source text, including whether legacy decoding was required.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedSource {
+    pub content: String,
+    /// `None` when the on-disk bytes were already valid UTF-8.
+    pub decoded_from: Option<&'static str>,
+}
+
+/// Read a source file as Unicode text.
+///
+/// Valid UTF-8 is returned as-is. Otherwise we honor UTF-16 BOMs, then use
+/// `chardetng` + `encoding_rs` so legacy-encoded sources can still be parsed.
+pub fn read_source_file(path: &Path) -> std::io::Result<DecodedSource> {
+    let bytes = std::fs::read(path)?;
+    Ok(decode_source_bytes(&bytes))
+}
+
+/// Decode source bytes to Unicode for Tree-sitter / JSSG analysis.
+pub fn decode_source_bytes(bytes: &[u8]) -> DecodedSource {
+    if let Ok(content) = std::str::from_utf8(bytes) {
+        return DecodedSource {
+            content: content.to_owned(),
+            decoded_from: None,
+        };
+    }
+
+    // Prefer explicit BOMs before statistical detection.
+    if bytes.starts_with(&[0xFF, 0xFE]) {
+        let (content, _, _) = encoding_rs::UTF_16LE.decode(bytes);
+        return DecodedSource {
+            content: content.into_owned(),
+            decoded_from: Some("UTF-16LE"),
+        };
+    }
+    if bytes.starts_with(&[0xFE, 0xFF]) {
+        let (content, _, _) = encoding_rs::UTF_16BE.decode(bytes);
+        return DecodedSource {
+            content: content.into_owned(),
+            decoded_from: Some("UTF-16BE"),
+        };
+    }
+
+    let mut detector = chardetng::EncodingDetector::new();
+    detector.feed(bytes, true);
+    let encoding = detector.guess(None, true);
+    let (content, used, _) = encoding.decode(bytes);
+    DecodedSource {
+        content: content.into_owned(),
+        decoded_from: Some(used.name()),
+    }
 }
 
 /// Async file writer that batches writes to reduce I/O contention
@@ -48,5 +100,25 @@ impl AsyncFileWriter {
 
         rx.await
             .map_err(|_| std::io::Error::other("File write operation canceled"))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_source_bytes_keeps_utf8() {
+        let decoded = decode_source_bytes(b"var x = 1;\n");
+        assert_eq!(decoded.content, "var x = 1;\n");
+        assert_eq!(decoded.decoded_from, None);
+    }
+
+    #[test]
+    fn decode_source_bytes_handles_windows_1252() {
+        // `café` with Windows-1252 é (0xE9)
+        let decoded = decode_source_bytes(&[b'c', b'a', b'f', 0xE9]);
+        assert_eq!(decoded.content, "café");
+        assert!(decoded.decoded_from.is_some());
     }
 }

--- a/crates/core/src/jssg_execution_service.rs
+++ b/crates/core/src/jssg_execution_service.rs
@@ -866,7 +866,8 @@ impl<'a> JssgExecutionService<'a> {
                                                 let original = if change_path == file_path {
                                                     content.clone()
                                                 } else {
-                                                    std::fs::read_to_string(change_path)
+                                                    read_source_file(change_path)
+                                                        .map(|decoded| decoded.content)
                                                         .unwrap_or_default()
                                                 };
                                                 callback(DryRunChange {
@@ -895,7 +896,8 @@ impl<'a> JssgExecutionService<'a> {
                                                 let original = if change_path == file_path {
                                                     content.clone()
                                                 } else {
-                                                    std::fs::read_to_string(change_path)
+                                                    read_source_file(change_path)
+                                                        .map(|decoded| decoded.content)
                                                         .unwrap_or_default()
                                                 };
                                                 callback(DryRunChange {

--- a/crates/core/src/jssg_execution_service.rs
+++ b/crates/core/src/jssg_execution_service.rs
@@ -42,6 +42,7 @@ use crate::{
         resolve_optional_glob_list, CapabilitiesData, Engine, StepPhase, StepProgressState,
     },
     execution::{CodemodExecutionConfig, PreRunCallback},
+    file_ops::read_source_file,
     progress_output::{
         append_buffered_diagnostic, append_buffered_log, flush_buffered_execution_output,
         BufferedExecutionOutput,
@@ -362,8 +363,8 @@ impl<'a> JssgExecutionService<'a> {
 
         for file_path in &target_files {
             if file_path.is_file() {
-                if let Ok(content) = std::fs::read_to_string(file_path) {
-                    if let Err(e) = provider.notify_file_processed(file_path, &content) {
+                if let Ok(decoded) = read_source_file(file_path) {
+                    if let Err(e) = provider.notify_file_processed(file_path, &decoded.content) {
                         slog!(
                             logger,
                             debug,
@@ -610,8 +611,8 @@ impl<'a> JssgExecutionService<'a> {
                     );
                     Self::signal_progress(&progress_tx_for_closure);
 
-                    let content = match std::fs::read_to_string(file_path) {
-                        Ok(content) => content,
+                    let decoded = match read_source_file(file_path) {
+                        Ok(decoded) => decoded,
                         Err(e) => {
                             slog!(
                                 logger,
@@ -661,6 +662,18 @@ impl<'a> JssgExecutionService<'a> {
                             return;
                         }
                     };
+                    if let Some(encoding) = decoded.decoded_from {
+                        let decode_message = format!(
+                            "Decoded non-UTF-8 source as {encoding} for analysis (writes UTF-8 only if modified): {relative_path}"
+                        );
+                        slog!(logger, warn, "{}", decode_message);
+                        append_buffered_log(
+                            &buffered_execution_output_for_closure,
+                            relative_path.clone(),
+                            decode_message,
+                        );
+                    }
+                    let content = decoded.content;
                     record_unit_progress(
                         &progress_state_for_closure,
                         &relative_path,

--- a/crates/core/tests/engine_tests.rs
+++ b/crates/core/tests/engine_tests.rs
@@ -1933,29 +1933,17 @@ async fn test_template_workflow() {
         .await
         .unwrap();
 
-    // Allow some time for the workflow to start
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-
-    // Get the workflow run
-    let workflow_run = engine.get_workflow_run(workflow_run_id).await.unwrap();
-
-    // Check that the workflow run is running or completed
+    let status = wait_for_workflow_status(&engine, workflow_run_id, |status| {
+        status == WorkflowStatus::Running || status == WorkflowStatus::Completed
+    })
+    .await;
     assert!(
-        workflow_run.status == WorkflowStatus::Running
-            || workflow_run.status == WorkflowStatus::Completed
+        status == WorkflowStatus::Running || status == WorkflowStatus::Completed,
+        "unexpected workflow status: {status:?}"
     );
 
-    // Get the tasks
-    let tasks = engine.get_tasks(workflow_run_id).await.unwrap();
-
-    // There should be at least 1 task
-    assert!(!tasks.is_empty());
-
-    // Check that the task for node1 exists
-    let node1_task = tasks.iter().find(|t| t.node_id == "node1").unwrap();
-
-    // Print the task status for debugging
-    println!("Node1 task status: {:?}", node1_task.status);
+    let node1_status = wait_for_task_status(&engine, workflow_run_id, "node1", |_| true).await;
+    println!("Node1 task status: {node1_status:?}");
 }
 
 // Test for trigger_all method

--- a/crates/core/tests/engine_tests.rs
+++ b/crates/core/tests/engine_tests.rs
@@ -5386,6 +5386,93 @@ export default function transform(ast) {
 }
 
 #[tokio::test]
+async fn test_execute_js_ast_grep_step_decodes_non_utf8_files() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    create_test_file(
+        temp_path,
+        "codemod.js",
+        r#"
+export default function transform(ast) {
+  // Read-only mining style: touch the AST API, return no edits.
+  void ast.filename();
+  return null;
+}
+"#,
+    );
+
+    create_test_file(temp_path, "src/good.js", "var good = 1;\n");
+    let legacy_path = temp_path.join("src/legacy.js");
+    fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
+    // Windows-1252: `var good = "café";\n` where é is byte 0xE9 (invalid UTF-8 alone).
+    let legacy_bytes = [
+        b'v', b'a', b'r', b' ', b'g', b'o', b'o', b'd', b' ', b'=', b' ', b'"', b'c', b'a', b'f',
+        0xE9, b'"', b';', b'\n',
+    ];
+    fs::write(&legacy_path, legacy_bytes).unwrap();
+
+    let config = workflow_run_config! {
+        bundle_path: temp_path.to_path_buf(),
+        target_path: temp_path.to_path_buf(),
+        ..WorkflowRunConfig::default()
+    };
+    let engine = Engine::with_workflow_run_config(config);
+    let result = engine
+        .execute_js_ast_grep_step(
+            "test-node".to_string(),
+            None,
+            "test-step".to_string(),
+            "test-step".to_string(),
+            None,
+            None,
+            &UseJSAstGrep {
+                js_file: "codemod.js".to_string(),
+                base_path: Some("src".to_string()),
+                include: Some(vec!["**/*.js".to_string()]),
+                exclude: None,
+                max_threads: Some(1),
+                dry_run: Some(false),
+                language: Some("javascript".to_string()),
+                capabilities: None,
+                semantic_analysis: Some(SemanticAnalysisConfig::Mode(SemanticAnalysisMode::File)),
+            },
+            None,
+            None,
+            &CapabilitiesData {
+                capabilities: None,
+                capabilities_security_callback: None,
+            },
+            &None,
+            None,
+            None,
+            &StructuredLogger::default(),
+            None,
+            None,
+            None,
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "legacy-encoded files should decode and parse instead of failing: {result:?}"
+    );
+    assert_eq!(
+        fs::read(&legacy_path).unwrap(),
+        legacy_bytes,
+        "unmodified legacy files must keep their original on-disk encoding"
+    );
+    assert_eq!(
+        engine
+            .execution_stats
+            .files_with_errors
+            .load(Ordering::Relaxed),
+        0,
+        "decoded legacy files must not count as errors"
+    );
+}
+
+#[tokio::test]
 async fn test_execute_js_ast_grep_step_fails_when_all_files_fail() {
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path();


### PR DESCRIPTION
## Summary
- Decode non-UTF-8 source files (UTF-16 BOM, then `chardetng` + `encoding_rs`) so JSSG workflow steps and `jssg run` can analyze legacy-encoded sources instead of failing with `stream did not contain valid UTF-8`.
- Leave unmodified on-disk bytes unchanged; only modified files write back as UTF-8 (with a warning log).
- Add unit decode tests and a workflow regression that covers Windows-1252 input under a JSSG step.

## Test plan
- [x] `cargo test -p butterflow-core decode_source_bytes`
- [x] `cargo test -p butterflow-core test_execute_js_ast_grep_step_decodes_non_utf8_files -- --nocapture`
- [x] Run a workflow against a repo with Windows-1252 `.cs` files (e.g. NopCommerce-style) and confirm steps complete without UTF-8 read errors
- [x] Confirm an unmodified legacy-encoded file keeps its original bytes after a dry-run / mining transform


Made with [Cursor](https://cursor.com)