### PR TITLE
fix(report-ui): prevent feedback modal error banner from overflowing

### DIFF
--- a/crates/cli/report-ui/src/components/feedback-button.tsx
+++ b/crates/cli/report-ui/src/components/feedback-button.tsx
@@ -42,6 +42,13 @@ type FeedbackStreamEvent =
 
 const ACTIVITY_PLACEHOLDER = "Agent activity will appear here while the draft is prepared.";
 const MAX_FEEDBACK_MESSAGE_LEN = 2500;
+const MAX_ERROR_MESSAGE_LEN = 300;
+
+function truncateError(message: string): string {
+  return message.length > MAX_ERROR_MESSAGE_LEN
+    ? `${message.slice(0, MAX_ERROR_MESSAGE_LEN)}…`
+    : message;
+}
 const SUPPORTED_AGENT_ORDER = ["claude-code", "codex", "opencode", "goose"];
 
 function getSupportedAgents(agents: AgentOption[] | undefined): AgentOption[] {
@@ -134,7 +141,7 @@ export function FeedbackButton() {
       setPreferredAgent((current) => resolvePreferredAgentCanonical(current, data));
       setState("idle");
     } catch (e: any) {
-      setErrorMsg(e.message || "Failed to load feedback status");
+      setErrorMsg(truncateError(e.message || "Failed to load feedback status"));
       setState("error");
     }
   }
@@ -169,7 +176,7 @@ export function FeedbackButton() {
       setState("submitted");
       setMode("choice");
     } catch (e: any) {
-      setErrorMsg(e.message || "Failed to submit feedback");
+      setErrorMsg(truncateError(e.message || "Failed to submit feedback"));
       setState("error");
     }
   }
@@ -194,7 +201,7 @@ export function FeedbackButton() {
 
       await readFeedbackStream(resp.body);
     } catch (e: any) {
-      setErrorMsg(e.message || "Failed to draft feedback");
+      setErrorMsg(truncateError(e.message || "Failed to draft feedback"));
       setState("error");
     }
   }
@@ -332,7 +339,7 @@ export function FeedbackButton() {
             ) : (
               <div className="space-y-4">
                 {errorMsg && (
-                  <p className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                  <p className="max-h-32 overflow-y-auto rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs break-words whitespace-pre-wrap text-destructive">
                     {errorMsg}
                   </p>
                 )}
@@ -429,7 +436,7 @@ export function FeedbackButton() {
           ) : (
             <div className="space-y-4">
               {errorMsg && (
-                <p className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <p className="max-h-32 overflow-y-auto rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs break-words whitespace-pre-wrap text-destructive">
                   {errorMsg}
                 </p>
               )}


### PR DESCRIPTION
## Summary

- When agent feedback drafting fails, the raw error message (sometimes containing large hook/session JSON payloads) was rendered in the feedback modal's error banner with no wrapping or size limit, causing it to overflow outside the dialog bounds.
- Both error banners in `feedback-button.tsx` now wrap/scroll long text (`break-words whitespace-pre-wrap max-h-32 overflow-y-auto`) instead of blowing out the layout.
- Added a `truncateError` helper (300-char cap) applied at all `setErrorMsg` call sites, so oversized error payloads are capped before they even reach the display layer.

## Test plan

- [x] `pnpm run lint` — 0 warnings/errors
- [x] `pnpm run format` — all files correctly formatted
- [x] `tsc --noEmit` in `crates/cli/report-ui` — no type errors
- [x] Manually verified in the dev server (mock API) with a simulated long error payload that the banner now wraps/scrolls within the dialog instead of overflowing
