### PR TITLE
[CDMD-4896] Add CLI publish tags and SemVer prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,7 @@ dependencies = [
  "rolldown",
  "rustls 0.21.12",
  "semantic-factory",
+ "semver",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_json_canonicalizer = "0.2"
 serde_yaml = "0.9"
+semver = "1.0"
 tar = "0.4"
 tempfile = "3.8"
 thiserror = "2.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,6 +32,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_json_canonicalizer = { workspace = true }
 serde_yaml = { workspace = true }
+semver = { workspace = true }
 anyhow = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }

--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Result};
 use butterflow_core::utils::validate_workflow;
 use butterflow_core::Workflow;
 use butterflow_models::step::StepAction;
-use clap::Args;
+use clap::{Args, ValueEnum};
 use codemod_llrt_capabilities::module_builder::supported_runtime_external_modules;
 use console::style;
 use log::{debug, info, warn};
@@ -33,10 +33,30 @@ use crate::commands::TelemetrySenderExt;
 use crate::{TelemetrySenderMutex, CLI_VERSION};
 use codemod_telemetry::send_event::BaseEvent;
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub enum PublishTag {
+    #[default]
+    Latest,
+    CodemodBuilder,
+}
+
+impl PublishTag {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Latest => "latest",
+            Self::CodemodBuilder => "codemod-builder",
+        }
+    }
+}
+
 #[derive(Args, Debug)]
 pub struct Command {
     /// Path to codemod directory
     path: Option<PathBuf>,
+
+    /// Release channel to update
+    #[arg(long, value_enum, default_value = "latest")]
+    tag: PublishTag,
 }
 
 #[derive(Deserialize, Debug)]
@@ -90,7 +110,14 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     };
 
     // Upload package
-    let response = upload_package(&registry_url, &bundle_path, &manifest, &access_token).await?;
+    let response = upload_package(
+        &registry_url,
+        &bundle_path,
+        &manifest,
+        &access_token,
+        args.tag,
+    )
+    .await?;
 
     if !response.success {
         return Err(anyhow!("Failed to publish package"));
@@ -307,7 +334,7 @@ fn validate_common_package_metadata(package_path: &Path, manifest: &CodemodManif
     // Validate version format (semver)
     if !is_valid_semver(&manifest.version) {
         return Err(anyhow!(
-            "Invalid version: {}. Must be valid semantic version (x.y.z).",
+            "Invalid version: {}. Must be a valid semantic version.",
             manifest.version
         ));
     }
@@ -486,6 +513,7 @@ async fn upload_package(
     bundle_path: &Path,
     manifest: &CodemodManifest,
     access_token: &str,
+    tag: PublishTag,
 ) -> Result<PublishResponse> {
     let client = reqwest::Client::new();
 
@@ -513,7 +541,8 @@ async fn upload_package(
                 .file_name(format!("{}-{}.tar.gz", manifest.name, manifest.version))
                 .mime_str("application/gzip")?,
         )
-        .text("manifest", manifest_json);
+        .text("manifest", manifest_json)
+        .text("tag", tag.as_str());
 
     debug!("Uploading to: {url}");
 
@@ -601,17 +630,7 @@ fn validate_package_name(name: &str) -> Result<()> {
 }
 
 fn is_valid_semver(version: &str) -> bool {
-    // Basic semver validation (x.y.z format)
-    let parts: Vec<&str> = version.split('.').collect();
-    if parts.len() != 3 {
-        return false;
-    }
-
-    parts.iter().all(|part| {
-        part.chars().all(|c| c.is_ascii_digit())
-            && !part.is_empty()
-            && (*part == "0" || !part.starts_with('0'))
-    })
+    semver::Version::parse(version).is_ok()
 }
 
 fn format_package_name(package: &PublishedPackage) -> String {
@@ -637,7 +656,114 @@ fn get_stored_auth_token(storage: &TokenStorage, registry_url: &str) -> Result<S
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+    use hyper::service::{make_service_fn, service_fn};
+    use hyper::{Body, Response, Server};
+    use std::convert::Infallible;
+    use std::sync::{Arc, Mutex};
     use tempfile::tempdir;
+    use tokio::sync::oneshot;
+
+    #[derive(Debug, Parser)]
+    struct PublishArgs {
+        #[command(flatten)]
+        command: Command,
+    }
+
+    #[test]
+    fn publish_defaults_to_latest_tag() {
+        let args = PublishArgs::try_parse_from(["publish"]).unwrap();
+
+        assert_eq!(args.command.tag, PublishTag::Latest);
+    }
+
+    #[test]
+    fn publish_accepts_builder_tag() {
+        let args = PublishArgs::try_parse_from(["publish", "--tag", "codemod-builder"]).unwrap();
+
+        assert_eq!(args.command.tag, PublishTag::CodemodBuilder);
+    }
+
+    #[test]
+    fn publish_rejects_unknown_tag() {
+        let error = PublishArgs::try_parse_from(["publish", "--tag", "preview"]).unwrap_err();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
+    }
+
+    #[test]
+    fn semver_validation_accepts_prereleases_and_build_metadata() {
+        assert!(is_valid_semver("0.0.1-codemod-builder.1"));
+        assert!(is_valid_semver("1.2.3-rc.1+build.42"));
+    }
+
+    #[test]
+    fn semver_validation_rejects_invalid_versions() {
+        assert!(!is_valid_semver("1.2"));
+        assert!(!is_valid_semver("01.2.3"));
+        assert!(!is_valid_semver("1.2.3-codemod_builder.1"));
+    }
+
+    #[tokio::test]
+    async fn upload_sends_requested_dist_tag() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let (body_sender, body_receiver) = oneshot::channel();
+        let body_sender = Arc::new(Mutex::new(Some(body_sender)));
+
+        let make_service = make_service_fn(move |_| {
+            let body_sender = Arc::clone(&body_sender);
+            async move {
+                Ok::<_, Infallible>(service_fn(move |request| {
+                    let body_sender = Arc::clone(&body_sender);
+                    async move {
+                        let body = hyper::body::to_bytes(request.into_body()).await.unwrap();
+                        if let Some(sender) = body_sender.lock().unwrap().take() {
+                            let _ = sender.send(body.to_vec());
+                        }
+
+                        let response = serde_json::json!({
+                            "success": true,
+                            "package": {
+                                "id": "pkg_1",
+                                "name": "example",
+                                "version": "0.0.1-codemod-builder.1",
+                                "scope": null,
+                                "published_at": "2026-08-12T00:00:00.000Z"
+                            }
+                        });
+                        Ok::<_, Infallible>(Response::new(Body::from(response.to_string())))
+                    }
+                }))
+            }
+        });
+        let server = Server::from_tcp(listener).unwrap().serve(make_service);
+        let server_handle = tokio::spawn(server);
+
+        let temp_dir = tempdir().unwrap();
+        let bundle_path = temp_dir.path().join("example.tar.gz");
+        fs::write(&bundle_path, b"bundle").unwrap();
+        let mut manifest = manifest_with(DEFAULT_WORKFLOW_FILE_NAME, "example");
+        manifest.version = "0.0.1-codemod-builder.1".to_string();
+
+        let response = upload_package(
+            &format!("http://{address}"),
+            &bundle_path,
+            &manifest,
+            "token",
+            PublishTag::CodemodBuilder,
+        )
+        .await
+        .unwrap();
+        assert!(response.success);
+
+        let request_body = body_receiver.await.unwrap();
+        let request_body = String::from_utf8_lossy(&request_body);
+        assert!(request_body.contains("name=\"tag\"\r\n\r\ncodemod-builder\r\n"));
+
+        server_handle.abort();
+    }
 
     fn create_authored_skill_bundle(package_path: &Path, package_name: &str) {
         let skill_file = expected_authored_skill_file(package_path, package_name);

--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Result};
 use butterflow_core::utils::validate_workflow;
 use butterflow_core::Workflow;
 use butterflow_models::step::StepAction;
-use clap::{Args, ValueEnum};
+use clap::Args;
 use codemod_llrt_capabilities::module_builder::supported_runtime_external_modules;
 use console::style;
 use log::{debug, info, warn};
@@ -33,30 +33,14 @@ use crate::commands::TelemetrySenderExt;
 use crate::{TelemetrySenderMutex, CLI_VERSION};
 use codemod_telemetry::send_event::BaseEvent;
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
-pub enum PublishTag {
-    #[default]
-    Latest,
-    CodemodBuilder,
-}
-
-impl PublishTag {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Latest => "latest",
-            Self::CodemodBuilder => "codemod-builder",
-        }
-    }
-}
-
 #[derive(Args, Debug)]
 pub struct Command {
     /// Path to codemod directory
     path: Option<PathBuf>,
 
     /// Release channel to update
-    #[arg(long, value_enum, default_value = "latest")]
-    tag: PublishTag,
+    #[arg(long, default_value = "latest")]
+    tag: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -115,7 +99,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         &bundle_path,
         &manifest,
         &access_token,
-        args.tag,
+        &args.tag,
     )
     .await?;
 
@@ -513,7 +497,7 @@ async fn upload_package(
     bundle_path: &Path,
     manifest: &CodemodManifest,
     access_token: &str,
-    tag: PublishTag,
+    tag: &str,
 ) -> Result<PublishResponse> {
     let client = reqwest::Client::new();
 
@@ -542,7 +526,7 @@ async fn upload_package(
                 .mime_str("application/gzip")?,
         )
         .text("manifest", manifest_json)
-        .text("tag", tag.as_str());
+        .text("tag", tag.to_owned());
 
     debug!("Uploading to: {url}");
 
@@ -674,21 +658,21 @@ mod tests {
     fn publish_defaults_to_latest_tag() {
         let args = PublishArgs::try_parse_from(["publish"]).unwrap();
 
-        assert_eq!(args.command.tag, PublishTag::Latest);
+        assert_eq!(args.command.tag, "latest");
     }
 
     #[test]
     fn publish_accepts_builder_tag() {
         let args = PublishArgs::try_parse_from(["publish", "--tag", "codemod-builder"]).unwrap();
 
-        assert_eq!(args.command.tag, PublishTag::CodemodBuilder);
+        assert_eq!(args.command.tag, "codemod-builder");
     }
 
     #[test]
-    fn publish_rejects_unknown_tag() {
-        let error = PublishArgs::try_parse_from(["publish", "--tag", "preview"]).unwrap_err();
+    fn publish_accepts_arbitrary_tag() {
+        let args = PublishArgs::try_parse_from(["publish", "--tag", "preview"]).unwrap();
 
-        assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
+        assert_eq!(args.command.tag, "preview");
     }
 
     #[test]
@@ -752,7 +736,7 @@ mod tests {
             &bundle_path,
             &manifest,
             "token",
-            PublishTag::CodemodBuilder,
+            "codemod-builder",
         )
         .await
         .unwrap();

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -712,16 +712,34 @@ fn determine_version(spec: &PackageSpec, package_info: &PackageInfo) -> Result<S
             }
         }
 
+        if selector == "latest" {
+            if let Some(version) = package_info
+                .latest_version
+                .as_ref()
+                .filter(|version| package_info.versions.contains_key(*version))
+            {
+                return Ok(version.clone());
+            }
+        }
+
         return Err(RegistryError::VersionNotFound {
             version: selector.clone(),
             package: format_package_spec(spec),
         });
     }
 
-    package_info
+    if let Some(version) = package_info
         .dist_tags
         .get("latest")
-        .or(package_info.latest_version.as_ref())
+        .filter(|version| package_info.versions.contains_key(*version))
+    {
+        return Ok(version.clone());
+    }
+
+    package_info
+        .latest_version
+        .as_ref()
+        .filter(|version| package_info.versions.contains_key(*version))
         .cloned()
         .ok_or_else(|| RegistryError::NoVersionAvailable {
             package: format_package_spec(spec),
@@ -838,6 +856,34 @@ mod tests {
         };
         let mut package_info = package_info_with_dist_tags();
         package_info.latest_version = Some("0.9.0".to_string());
+
+        assert_eq!(determine_version(&spec, &package_info).unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn determine_version_resolves_explicit_latest_from_legacy_projection() {
+        let spec = PackageSpec {
+            scope: Some("@codemod".to_string()),
+            name: "example".to_string(),
+            version: Some("latest".to_string()),
+        };
+        let mut package_info = package_info_with_dist_tags();
+        package_info.dist_tags.clear();
+
+        assert_eq!(determine_version(&spec, &package_info).unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn determine_version_ignores_stale_latest_dist_tag() {
+        let spec = PackageSpec {
+            scope: Some("@codemod".to_string()),
+            name: "example".to_string(),
+            version: None,
+        };
+        let mut package_info = package_info_with_dist_tags();
+        package_info
+            .dist_tags
+            .insert("latest".to_string(), "2.0.0".to_string());
 
         assert_eq!(determine_version(&spec, &package_info).unwrap(), "1.0.0");
     }

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -120,6 +120,8 @@ struct PackageInfo {
     scope: Option<String>,
     is_legacy: bool,
     latest_version: Option<String>,
+    #[serde(default)]
+    dist_tags: HashMap<String, String>,
     versions: HashMap<String, PackageVersion>,
     #[serde(default)]
     access: Option<String>,
@@ -699,22 +701,31 @@ pub fn format_package_spec(spec: &PackageSpec) -> String {
 }
 
 fn determine_version(spec: &PackageSpec, package_info: &PackageInfo) -> Result<String> {
-    if let Some(version) = &spec.version {
-        if package_info.versions.contains_key(version) {
-            Ok(version.clone())
-        } else {
-            Err(RegistryError::VersionNotFound {
-                version: version.clone(),
-                package: format_package_spec(spec),
-            })
+    if let Some(selector) = &spec.version {
+        if package_info.versions.contains_key(selector) {
+            return Ok(selector.clone());
         }
-    } else if let Some(latest) = &package_info.latest_version {
-        Ok(latest.clone())
-    } else {
-        Err(RegistryError::NoVersionAvailable {
+
+        if let Some(version) = package_info.dist_tags.get(selector) {
+            if package_info.versions.contains_key(version) {
+                return Ok(version.clone());
+            }
+        }
+
+        return Err(RegistryError::VersionNotFound {
+            version: selector.clone(),
+            package: format_package_spec(spec),
+        });
+    }
+
+    package_info
+        .dist_tags
+        .get("latest")
+        .or(package_info.latest_version.as_ref())
+        .cloned()
+        .ok_or_else(|| RegistryError::NoVersionAvailable {
             package: format_package_spec(spec),
         })
-    }
 }
 
 fn is_package_cached(package_dir: &Path) -> Result<bool> {
@@ -778,6 +789,58 @@ mod tests {
     use std::io::{Cursor, Write};
     use std::sync::Mutex;
     use tokio::net::TcpListener;
+
+    #[test]
+    fn parse_package_spec_accepts_builder_tag() {
+        let spec = parse_package_spec("@codemod/example@codemod-builder").unwrap();
+
+        assert_eq!(spec.scope.as_deref(), Some("@codemod"));
+        assert_eq!(spec.name, "example");
+        assert_eq!(spec.version.as_deref(), Some("codemod-builder"));
+    }
+
+    #[test]
+    fn determine_version_resolves_builder_tag() {
+        let spec = PackageSpec {
+            scope: Some("@codemod".to_string()),
+            name: "example".to_string(),
+            version: Some("codemod-builder".to_string()),
+        };
+        let package_info = package_info_with_dist_tags();
+
+        assert_eq!(
+            determine_version(&spec, &package_info).unwrap(),
+            "0.0.1-codemod-builder.1"
+        );
+    }
+
+    #[test]
+    fn determine_version_accepts_exact_prerelease() {
+        let spec = PackageSpec {
+            scope: Some("@codemod".to_string()),
+            name: "example".to_string(),
+            version: Some("0.0.1-codemod-builder.1".to_string()),
+        };
+        let package_info = package_info_with_dist_tags();
+
+        assert_eq!(
+            determine_version(&spec, &package_info).unwrap(),
+            "0.0.1-codemod-builder.1"
+        );
+    }
+
+    #[test]
+    fn determine_version_defaults_to_latest_dist_tag() {
+        let spec = PackageSpec {
+            scope: Some("@codemod".to_string()),
+            name: "example".to_string(),
+            version: None,
+        };
+        let mut package_info = package_info_with_dist_tags();
+        package_info.latest_version = Some("0.9.0".to_string());
+
+        assert_eq!(determine_version(&spec, &package_info).unwrap(), "1.0.0");
+    }
 
     #[tokio::test]
     async fn resolve_package_downloads_from_resolved_unscoped_package_info_path() {
@@ -963,6 +1026,35 @@ mod tests {
             }
         })
         .to_string()
+    }
+
+    fn package_info_with_dist_tags() -> PackageInfo {
+        serde_json::from_value(serde_json::json!({
+            "id": "pkg_1",
+            "name": "example",
+            "scope": "@codemod",
+            "is_legacy": false,
+            "latest_version": "1.0.0",
+            "dist_tags": {
+                "latest": "1.0.0",
+                "codemod-builder": "0.0.1-codemod-builder.1"
+            },
+            "versions": {
+                "1.0.0": {
+                    "version": "1.0.0",
+                    "description": null,
+                    "checksum": "sha256:latest",
+                    "size": 1
+                },
+                "0.0.1-codemod-builder.1": {
+                    "version": "0.0.1-codemod-builder.1",
+                    "description": null,
+                    "checksum": "sha256:builder",
+                    "size": 1
+                }
+            }
+        }))
+        .unwrap()
     }
 
     fn package_archive() -> Vec<u8> {


### PR DESCRIPTION
## Summary
- add `codemod publish --tag latest|codemod-builder`, defaulting to `latest`
- send the selected tag in the Registry multipart publish request
- validate manifest versions with standards-compliant SemVer, including Builder prereleases
- resolve Registry `dist_tags` for run/download while preserving exact-version and legacy `latest_version` behavior

## Testing
- `cargo test -p codemod commands::publish::tests` (21 passed)
- `CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 cargo test -p butterflow-core --lib registry::tests` (7 passed)
- `cargo fmt --all -- --check`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 cargo clippy -p codemod -p butterflow-core --tests --no-deps -- -D warnings`

## Manual integration testing
Tested against the local Registry at `http://localhost:3000` with an API token:

- `codemod publish --tag latest` published a prerelease and set only the `latest` tag
- `codemod publish --tag codemod-builder` published `0.0.1-codemod-builder.1` without changing `latest`
- `codemod publish` without `--tag` advanced `latest` while leaving `codemod-builder` pinned
- Registry metadata returned independent `latest` and `codemod-builder` mappings with all published versions present
- default, `@latest`, `@codemod-builder`, and exact prerelease selectors all downloaded and executed successfully through the CLI

## Dependency
Blocked on codemod/codemod-app#949 for Registry dist-tag persistence and API support.

Linear: https://linear.app/codemod/issue/CDMD-4896