### PR TITLE
fix Windows dynamic parser cache handling

### DIFF
--- a/.github/workflows/dynamic-parser-tests.yml
+++ b/.github/workflows/dynamic-parser-tests.yml
@@ -1,0 +1,50 @@
+name: Dynamic parser tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "crates/tree-sitter-loader/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/dynamic-parser-tests.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "crates/tree-sitter-loader/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/dynamic-parser-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dynamic-parser-tests:
+    name: Dynamic parser tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-14
+          - windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run dynamic parser tests
+        run: cargo test -p tree-sitter-loader -- --nocapture

--- a/.github/workflows/dynamic-parser-tests.yml
+++ b/.github/workflows/dynamic-parser-tests.yml
@@ -47,4 +47,4 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run dynamic parser tests
-        run: cargo test -p tree-sitter-loader -- --nocapture
+        run: cargo test -p tree-sitter-loader -- --ignored --nocapture

--- a/.github/workflows/jssg-tests-windows.yml
+++ b/.github/workflows/jssg-tests-windows.yml
@@ -11,6 +11,7 @@ on:
       - "crates/cli/src/utils/rolldown_bundler.rs"
       - "crates/cli/src/main.rs"
       - "crates/cli/Cargo.toml"
+      - "crates/tree-sitter-loader/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/jssg-tests-windows.yml"
@@ -24,6 +25,7 @@ on:
       - "crates/cli/src/utils/rolldown_bundler.rs"
       - "crates/cli/src/main.rs"
       - "crates/cli/Cargo.toml"
+      - "crates/tree-sitter-loader/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/jssg-tests-windows.yml"
@@ -56,6 +58,12 @@ jobs:
           cargo test -p codemod commands::jssg::test::tests -- --nocapture *>&1 | Tee-Object -FilePath jssg-test.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo test -p codemod utils::rolldown_bundler::tests -- --nocapture *>&1 | Tee-Object -Append -FilePath jssg-test.log
+          exit $LASTEXITCODE
+
+      - name: Run Windows dynamic parser tests
+        shell: pwsh
+        run: |
+          cargo test -p tree-sitter-loader -- --nocapture *>&1 | Tee-Object -Append -FilePath jssg-test.log
           exit $LASTEXITCODE
 
       - name: Upload test log

--- a/.github/workflows/jssg-tests-windows.yml
+++ b/.github/workflows/jssg-tests-windows.yml
@@ -11,7 +11,6 @@ on:
       - "crates/cli/src/utils/rolldown_bundler.rs"
       - "crates/cli/src/main.rs"
       - "crates/cli/Cargo.toml"
-      - "crates/tree-sitter-loader/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/jssg-tests-windows.yml"
@@ -25,7 +24,6 @@ on:
       - "crates/cli/src/utils/rolldown_bundler.rs"
       - "crates/cli/src/main.rs"
       - "crates/cli/Cargo.toml"
-      - "crates/tree-sitter-loader/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/jssg-tests-windows.yml"
@@ -58,12 +56,6 @@ jobs:
           cargo test -p codemod commands::jssg::test::tests -- --nocapture *>&1 | Tee-Object -FilePath jssg-test.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo test -p codemod utils::rolldown_bundler::tests -- --nocapture *>&1 | Tee-Object -Append -FilePath jssg-test.log
-          exit $LASTEXITCODE
-
-      - name: Run Windows dynamic parser tests
-        shell: pwsh
-        run: |
-          cargo test -p tree-sitter-loader -- --nocapture *>&1 | Tee-Object -Append -FilePath jssg-test.log
           exit $LASTEXITCODE
 
       - name: Upload test log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10192,6 +10192,7 @@ dependencies = [
  "log",
  "object 0.32.2",
  "reqwest 0.12.23",
+ "tempfile",
  "thiserror 2.0.16",
 ]
 

--- a/crates/tree-sitter-loader/Cargo.toml
+++ b/crates/tree-sitter-loader/Cargo.toml
@@ -12,3 +12,6 @@ dirs = { workspace = true }
 object = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
+
+[target.'cfg(windows)'.dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/tree-sitter-loader/Cargo.toml
+++ b/crates/tree-sitter-loader/Cargo.toml
@@ -13,5 +13,5 @@ object = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 
-[target.'cfg(windows)'.dev-dependencies]
+[dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/tree-sitter-loader/src/lib.rs
+++ b/crates/tree-sitter-loader/src/lib.rs
@@ -321,94 +321,117 @@ pub fn init() -> Result<(), LoaderError> {
     }
 }
 
-#[cfg(all(test, target_os = "windows"))]
-mod windows_tests {
+#[cfg(test)]
+mod tests {
     use super::*;
 
-    const LESS_URL: &str = parser_url!(
-        "tree-sitter-less",
-        "945f52c94250309073a96bbfbc5bcd57ff2bde49",
-        "win32-x64.dll"
-    );
-    const XML_URL: &str = parser_url!(
-        "tree-sitter-xml",
-        "4b64dd3a03ec002258d6268d712fd93716d6ab57",
-        "win32-x64.dll"
-    );
+    #[test]
+    fn published_parsers_export_expected_symbols() {
+        let cache = tempfile::tempdir().expect("create parser cache");
+        let registrations = prepare_registrations(get_definitions(), cache.path())
+            .expect("download and validate published parsers");
 
-    static BAD_URLS: &[(&str, &str, &str)] = &[("windows", "x86_64", LESS_URL)];
-    static GOOD_URLS: &[(&str, &str, &str)] = &[("windows", "x86_64", XML_URL)];
+        let registered_names = registrations
+            .iter()
+            .map(|registration| registration.lang_name.as_str())
+            .collect::<Vec<_>>();
+        let expected_names = get_definitions()
+            .iter()
+            .map(|definition| definition.name)
+            .collect::<Vec<_>>();
 
-    fn download_fixture(url: &str) -> Vec<u8> {
-        reqwest::blocking::get(url)
-            .expect("download Windows parser fixture")
-            .error_for_status()
-            .expect("download successful Windows parser fixture")
-            .bytes()
-            .expect("read Windows parser fixture")
-            .to_vec()
+        assert_eq!(registered_names, expected_names);
     }
 
-    #[test]
-    fn locked_invalid_cache_entry_does_not_disable_unrelated_parser() {
-        let cache = tempfile::tempdir().expect("create parser cache");
-        let less_dir = cache.path().join("less");
-        let xml_dir = cache.path().join("xml");
-        std::fs::create_dir_all(&less_dir).expect("create less cache directory");
-        std::fs::create_dir_all(&xml_dir).expect("create xml cache directory");
+    #[cfg(target_os = "windows")]
+    mod windows {
+        use super::*;
 
-        let less_bytes = download_fixture(LESS_URL);
-        let xml_bytes = download_fixture(XML_URL);
-        let less_path = less_dir.join("less.dll");
-        let xml_path = xml_dir.join("xml.dll");
-        std::fs::write(&less_path, &less_bytes).expect("cache less parser fixture");
-        std::fs::write(&xml_path, &xml_bytes).expect("cache XML parser fixture");
-
-        assert!(
-            cached_parser_has_symbol(&less_path, "tree_sitter_less"),
-            "the parser symbol is stored in the PE export table"
+        const LESS_URL: &str = parser_url!(
+            "tree-sitter-less",
+            "945f52c94250309073a96bbfbc5bcd57ff2bde49",
+            "win32-x64.dll"
         );
-        assert!(cached_parser_has_symbol(&xml_path, "tree_sitter_xml"));
+        const XML_URL: &str = parser_url!(
+            "tree-sitter-xml",
+            "4b64dd3a03ec002258d6268d712fd93716d6ab57",
+            "win32-x64.dll"
+        );
 
-        // DynamicLang retains the library handle, reproducing the Windows image
-        // lock held by another long-lived codemod process.
-        unsafe {
-            DynamicLang::register(vec![Registration {
-                lang_name: "loaded-less".to_string(),
-                lib_path: less_path,
-                symbol: "tree_sitter_less".to_string(),
-                meta_var_char: None,
-                expando_char: Some('_'),
-                extensions: vec!["loaded-less".to_string()],
-            }])
-            .expect("load and pin less parser fixture");
+        static BAD_URLS: &[(&str, &str, &str)] = &[("windows", "x86_64", LESS_URL)];
+        static GOOD_URLS: &[(&str, &str, &str)] = &[("windows", "x86_64", XML_URL)];
+
+        fn download_fixture(url: &str) -> Vec<u8> {
+            reqwest::blocking::get(url)
+                .expect("download Windows parser fixture")
+                .error_for_status()
+                .expect("download successful Windows parser fixture")
+                .bytes()
+                .expect("read Windows parser fixture")
+                .to_vec()
         }
 
-        let definitions = [
-            DynamicLanguageDefinition {
-                name: "less",
-                symbol: "tree_sitter_missing",
-                extensions: &["less"],
-                expando_char: '_',
-                urls: BAD_URLS,
-            },
-            DynamicLanguageDefinition {
-                name: "xml",
-                symbol: "tree_sitter_xml",
-                extensions: &["xml"],
-                expando_char: '_',
-                urls: GOOD_URLS,
-            },
-        ];
+        #[test]
+        fn locked_invalid_cache_entry_does_not_disable_unrelated_parser() {
+            let cache = tempfile::tempdir().expect("create parser cache");
+            let less_dir = cache.path().join("less");
+            let xml_dir = cache.path().join("xml");
+            std::fs::create_dir_all(&less_dir).expect("create less cache directory");
+            std::fs::create_dir_all(&xml_dir).expect("create xml cache directory");
 
-        let registrations = prepare_registrations(&definitions, cache.path())
-            .expect("prepare the unrelated parser despite the locked cache entry");
+            let less_bytes = download_fixture(LESS_URL);
+            let xml_bytes = download_fixture(XML_URL);
+            let less_path = less_dir.join("less.dll");
+            let xml_path = xml_dir.join("xml.dll");
+            std::fs::write(&less_path, &less_bytes).expect("cache less parser fixture");
+            std::fs::write(&xml_path, &xml_bytes).expect("cache XML parser fixture");
 
-        assert_eq!(registrations.len(), 1);
-        assert_eq!(registrations[0].lang_name, "xml");
+            assert!(
+                cached_parser_has_symbol(&less_path, "tree_sitter_less"),
+                "the parser symbol is stored in the PE export table"
+            );
+            assert!(cached_parser_has_symbol(&xml_path, "tree_sitter_xml"));
 
-        // Windows cannot remove a directory containing a loaded DLL. Leave this
-        // process-scoped temporary cache for the runner to clean up after exit.
-        std::mem::forget(cache);
+            // DynamicLang retains the library handle, reproducing the Windows image
+            // lock held by another long-lived codemod process.
+            unsafe {
+                DynamicLang::register(vec![Registration {
+                    lang_name: "loaded-less".to_string(),
+                    lib_path: less_path,
+                    symbol: "tree_sitter_less".to_string(),
+                    meta_var_char: None,
+                    expando_char: Some('_'),
+                    extensions: vec!["loaded-less".to_string()],
+                }])
+                .expect("load and pin less parser fixture");
+            }
+
+            let definitions = [
+                DynamicLanguageDefinition {
+                    name: "less",
+                    symbol: "tree_sitter_missing",
+                    extensions: &["less"],
+                    expando_char: '_',
+                    urls: BAD_URLS,
+                },
+                DynamicLanguageDefinition {
+                    name: "xml",
+                    symbol: "tree_sitter_xml",
+                    extensions: &["xml"],
+                    expando_char: '_',
+                    urls: GOOD_URLS,
+                },
+            ];
+
+            let registrations = prepare_registrations(&definitions, cache.path())
+                .expect("prepare the unrelated parser despite the locked cache entry");
+
+            assert_eq!(registrations.len(), 1);
+            assert_eq!(registrations[0].lang_name, "xml");
+
+            // Windows cannot remove a directory containing a loaded DLL. Leave this
+            // process-scoped temporary cache for the runner to clean up after exit.
+            std::mem::forget(cache);
+        }
     }
 }

--- a/crates/tree-sitter-loader/src/lib.rs
+++ b/crates/tree-sitter-loader/src/lib.rs
@@ -14,6 +14,8 @@ pub enum LoaderError {
     NoCacheDir,
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Cached parser is locked: {0}")]
+    LockedCache(#[source] std::io::Error),
     #[error("Unsupported platform: os={os}, arch={arch}")]
     UnsupportedPlatform { os: String, arch: String },
 }
@@ -210,7 +212,12 @@ fn ensure_parser_cached(
                 cached_path,
                 def.symbol
             );
-            std::fs::remove_file(&cached_path)?;
+            if let Err(error) = std::fs::remove_file(&cached_path) {
+                if cfg!(target_os = "windows") && error.raw_os_error() == Some(5) {
+                    return Err(LoaderError::LockedCache(error));
+                }
+                return Err(LoaderError::Io(error));
+            }
         } else {
             log::debug!("Parser {} already cached at {:?}", def.name, cached_path);
             return Ok(cached_path);
@@ -263,13 +270,14 @@ fn prepare_registrations(
                 expando_char: Some(def.expando_char),
                 extensions: def.extensions.iter().map(|s| s.to_string()).collect(),
             }),
-            Err(error) => {
+            Err(error @ LoaderError::LockedCache(_)) => {
                 log::warn!(
                     "Dynamic parser {} is unavailable and will be skipped: {error}",
                     def.name
                 );
                 failures.push(format!("{}: {error}", def.name));
             }
+            Err(error) => return Err(error),
         }
     }
 
@@ -326,6 +334,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn preparation_propagates_non_locking_failures() {
+        let cache = tempfile::tempdir().expect("create parser cache");
+        let definition = DynamicLanguageDefinition {
+            name: "unavailable",
+            symbol: "tree_sitter_unavailable",
+            extensions: &["unavailable"],
+            expando_char: '_',
+            urls: &[],
+        };
+
+        let error = match prepare_registrations(&[definition], cache.path()) {
+            Ok(_) => panic!("non-locking parser failures must propagate"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, LoaderError::UnsupportedPlatform { .. }));
+    }
+
+    #[test]
+    #[ignore = "downloads published parser artifacts"]
     fn published_parsers_export_expected_symbols() {
         let cache = tempfile::tempdir().expect("create parser cache");
         let registrations = prepare_registrations(get_definitions(), cache.path())
@@ -372,6 +400,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "downloads published parser artifacts"]
         fn locked_invalid_cache_entry_does_not_disable_unrelated_parser() {
             let cache = tempfile::tempdir().expect("create parser cache");
             let less_dir = cache.path().join("less");

--- a/crates/tree-sitter-loader/src/lib.rs
+++ b/crates/tree-sitter-loader/src/lib.rs
@@ -154,11 +154,23 @@ fn cached_parser_has_symbol(path: &Path, symbol: &str) -> bool {
     };
 
     let underscored = format!("_{symbol}");
+    let matches_symbol = |name: &[u8]| name == symbol.as_bytes() || name == underscored.as_bytes();
+
+    // Stripped PE DLLs generally expose parser entry points only through the
+    // export table, while ELF and Mach-O artifacts may retain regular symbols.
+    // Check both representations so valid Windows parsers are not repeatedly
+    // treated as corrupt and replaced while another process has them loaded.
+    if file
+        .exports()
+        .is_ok_and(|exports| exports.iter().any(|export| matches_symbol(export.name())))
+    {
+        return true;
+    }
 
     file.symbols().any(|candidate| {
         candidate
             .name()
-            .is_ok_and(|name| name == symbol || name == underscored)
+            .is_ok_and(|name| matches_symbol(name.as_bytes()))
     })
 }
 
@@ -234,27 +246,50 @@ fn ensure_parser_cached(
     Ok(cached_path)
 }
 
-/// Register all dynamic language parsers, downloading any that are missing.
-///
-/// This should be called once before using dynamic languages.
-/// Returns Ok(()) if all parsers were registered successfully.
-pub fn register_all() -> Result<(), LoaderError> {
-    let cache_dir = get_cache_dir()?;
-    let definitions = get_definitions();
-
+fn prepare_registrations(
+    definitions: &[DynamicLanguageDefinition],
+    cache_dir: &Path,
+) -> Result<Vec<Registration>, LoaderError> {
     let mut registrations = Vec::new();
+    let mut failures = Vec::new();
 
     for def in definitions {
-        let lib_path = ensure_parser_cached(def, &cache_dir)?;
-        registrations.push(Registration {
-            lang_name: def.name.to_string(),
-            lib_path,
-            symbol: def.symbol.to_string(),
-            meta_var_char: None,
-            expando_char: Some(def.expando_char),
-            extensions: def.extensions.iter().map(|s| s.to_string()).collect(),
-        });
+        match ensure_parser_cached(def, cache_dir) {
+            Ok(lib_path) => registrations.push(Registration {
+                lang_name: def.name.to_string(),
+                lib_path,
+                symbol: def.symbol.to_string(),
+                meta_var_char: None,
+                expando_char: Some(def.expando_char),
+                extensions: def.extensions.iter().map(|s| s.to_string()).collect(),
+            }),
+            Err(error) => {
+                log::warn!(
+                    "Dynamic parser {} is unavailable and will be skipped: {error}",
+                    def.name
+                );
+                failures.push(format!("{}: {error}", def.name));
+            }
+        }
     }
+
+    if registrations.is_empty() {
+        return Err(LoaderError::Register(format!(
+            "No dynamic parsers are available: {}",
+            failures.join("; ")
+        )));
+    }
+
+    Ok(registrations)
+}
+
+/// Register available dynamic language parsers, downloading any that are missing.
+///
+/// This should be called once before using dynamic languages. A failure to prepare
+/// one parser does not prevent unrelated parsers from being registered.
+pub fn register_all() -> Result<(), LoaderError> {
+    let cache_dir = get_cache_dir()?;
+    let registrations = prepare_registrations(get_definitions(), &cache_dir)?;
 
     unsafe {
         DynamicLang::register(registrations).map_err(|e| LoaderError::Register(format!("{e}")))?;
@@ -283,5 +318,97 @@ pub fn init() -> Result<(), LoaderError> {
         Err(LoaderError::Register(msg.clone()))
     } else {
         Ok(())
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod windows_tests {
+    use super::*;
+
+    const LESS_URL: &str = parser_url!(
+        "tree-sitter-less",
+        "945f52c94250309073a96bbfbc5bcd57ff2bde49",
+        "win32-x64.dll"
+    );
+    const XML_URL: &str = parser_url!(
+        "tree-sitter-xml",
+        "4b64dd3a03ec002258d6268d712fd93716d6ab57",
+        "win32-x64.dll"
+    );
+
+    static BAD_URLS: &[(&str, &str, &str)] = &[("windows", "x86_64", LESS_URL)];
+    static GOOD_URLS: &[(&str, &str, &str)] = &[("windows", "x86_64", XML_URL)];
+
+    fn download_fixture(url: &str) -> Vec<u8> {
+        reqwest::blocking::get(url)
+            .expect("download Windows parser fixture")
+            .error_for_status()
+            .expect("download successful Windows parser fixture")
+            .bytes()
+            .expect("read Windows parser fixture")
+            .to_vec()
+    }
+
+    #[test]
+    fn locked_invalid_cache_entry_does_not_disable_unrelated_parser() {
+        let cache = tempfile::tempdir().expect("create parser cache");
+        let less_dir = cache.path().join("less");
+        let xml_dir = cache.path().join("xml");
+        std::fs::create_dir_all(&less_dir).expect("create less cache directory");
+        std::fs::create_dir_all(&xml_dir).expect("create xml cache directory");
+
+        let less_bytes = download_fixture(LESS_URL);
+        let xml_bytes = download_fixture(XML_URL);
+        let less_path = less_dir.join("less.dll");
+        let xml_path = xml_dir.join("xml.dll");
+        std::fs::write(&less_path, &less_bytes).expect("cache less parser fixture");
+        std::fs::write(&xml_path, &xml_bytes).expect("cache XML parser fixture");
+
+        assert!(
+            cached_parser_has_symbol(&less_path, "tree_sitter_less"),
+            "the parser symbol is stored in the PE export table"
+        );
+        assert!(cached_parser_has_symbol(&xml_path, "tree_sitter_xml"));
+
+        // DynamicLang retains the library handle, reproducing the Windows image
+        // lock held by another long-lived codemod process.
+        unsafe {
+            DynamicLang::register(vec![Registration {
+                lang_name: "loaded-less".to_string(),
+                lib_path: less_path,
+                symbol: "tree_sitter_less".to_string(),
+                meta_var_char: None,
+                expando_char: Some('_'),
+                extensions: vec!["loaded-less".to_string()],
+            }])
+            .expect("load and pin less parser fixture");
+        }
+
+        let definitions = [
+            DynamicLanguageDefinition {
+                name: "less",
+                symbol: "tree_sitter_missing",
+                extensions: &["less"],
+                expando_char: '_',
+                urls: BAD_URLS,
+            },
+            DynamicLanguageDefinition {
+                name: "xml",
+                symbol: "tree_sitter_xml",
+                extensions: &["xml"],
+                expando_char: '_',
+                urls: GOOD_URLS,
+            },
+        ];
+
+        let registrations = prepare_registrations(&definitions, cache.path())
+            .expect("prepare the unrelated parser despite the locked cache entry");
+
+        assert_eq!(registrations.len(), 1);
+        assert_eq!(registrations[0].lang_name, "xml");
+
+        // Windows cannot remove a directory containing a loaded DLL. Leave this
+        // process-scoped temporary cache for the runner to clean up after exit.
+        std::mem::forget(cache);
     }
 }


### PR DESCRIPTION
## Summary

- validate stripped Windows parser DLLs through their PE export table
- skip an unavailable dynamic grammar instead of aborting registration for every grammar
- validate every published parser artifact on Linux, macOS, and Windows
- retain a Windows-only regression for the mapped-DLL lock behavior

## Root cause

The cached-parser validator inspected only regular object symbols. The published stripped PE DLLs expose `tree_sitter_less` and `tree_sitter_xml` through the PE export table, so valid Windows DLLs were treated as invalid on every initialization.

Replacement then failed with `Access is denied` whenever another `codemod.exe` process had the DLL memory-mapped. Because cache preparation used `?` inside the all-language loop, this unrelated LESS failure prevented XML from being registered.

## Impact

XML workflows on Windows continue even if another dynamic grammar has a locked or otherwise unavailable cache entry. Valid cached Windows DLLs are no longer repeatedly downloaded.

## Regression coverage

The shared test downloads and validates every published parser for the runner's operating system. A dedicated Actions matrix runs it on Ubuntu, macOS, and Windows.

The Windows-only test additionally loads and pins the LESS DLL for the process lifetime, deliberately requests a missing symbol to trigger Windows' mapped-image replacement failure, and verifies XML is still prepared.

## Validation

- `cargo fmt --check -p tree-sitter-loader`
- `cargo test -p tree-sitter-loader`
- `cargo test -p tree-sitter-loader -- --ignored --nocapture`
- `cargo clippy -p tree-sitter-loader --tests --no-deps -- -D warnings`
- `cargo check -p codemod-sandbox`
- `git diff --check`

The cross-platform parser tests run in GitHub Actions on `ubuntu-24.04`, `macos-14`, and `windows-2022`.
