### PR TITLE
CDMD-4902: publish musl-native CLI packages

### DIFF
--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -26,9 +26,15 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             binary_name: codemod-linux-x86_64-gnu
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            binary_name: codemod-linux-x86_64-musl
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             binary_name: codemod-linux-aarch64-gnu
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+            binary_name: codemod-linux-aarch64-musl
           - os: macos-latest
             target: aarch64-apple-darwin
             binary_name: codemod-darwin-aarch64
@@ -71,10 +77,14 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Install dependencies (Linux only)
-        if: matrix.os == 'ubuntu-22.04' || (matrix.os == 'self-hosted' && matrix.target == 'aarch64-unknown-linux-gnu')
+        if: startsWith(matrix.target, 'x86_64-unknown-linux') || startsWith(matrix.target, 'aarch64-unknown-linux')
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config build-essential libssl-dev
+
+      - name: Install musl toolchain (Linux musl only)
+        if: endsWith(matrix.target, '-musl')
+        run: sudo apt-get install -y musl-tools
 
       - name: Install GNU coreutils (macOS only)
         if: matrix.os == 'macos-latest'
@@ -255,12 +265,14 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: |
             x86_64-unknown-linux-gnu/*
+            x86_64-unknown-linux-musl/*
             aarch64-apple-darwin/*
             x86_64-apple-darwin/*
             x86_64-pc-windows-msvc/*
             i686-pc-windows-msvc/*
             aarch64-pc-windows-msvc/*
             aarch64-unknown-linux-gnu/*
+            aarch64-unknown-linux-musl/*
           generate_release_notes: true
 
   release_npm:
@@ -308,14 +320,18 @@ jobs:
           mkdir -p crates/cli/npm/platforms/darwin-arm64
           mkdir -p crates/cli/npm/platforms/darwin-x64  
           mkdir -p crates/cli/npm/platforms/linux-x64-gnu
+          mkdir -p crates/cli/npm/platforms/linux-x64-musl
           mkdir -p crates/cli/npm/platforms/linux-arm64-gnu
+          mkdir -p crates/cli/npm/platforms/linux-arm64-musl
           mkdir -p crates/cli/npm/platforms/win32-x64-msvc
 
           # Copy binaries to platform packages
           cp artifacts/aarch64-apple-darwin/codemod-darwin-aarch64 crates/cli/npm/platforms/darwin-arm64/codemod
           cp artifacts/x86_64-apple-darwin/codemod-darwin-x86_64 crates/cli/npm/platforms/darwin-x64/codemod
           cp artifacts/x86_64-unknown-linux-gnu/codemod-linux-x86_64-gnu crates/cli/npm/platforms/linux-x64-gnu/codemod
+          cp artifacts/x86_64-unknown-linux-musl/codemod-linux-x86_64-musl crates/cli/npm/platforms/linux-x64-musl/codemod
           cp artifacts/aarch64-unknown-linux-gnu/codemod-linux-aarch64-gnu crates/cli/npm/platforms/linux-arm64-gnu/codemod
+          cp artifacts/aarch64-unknown-linux-musl/codemod-linux-aarch64-musl crates/cli/npm/platforms/linux-arm64-musl/codemod
           cp artifacts/x86_64-pc-windows-msvc/codemod-windows-x86_64.exe crates/cli/npm/platforms/win32-x64-msvc/codemod.exe
 
           # Make binaries executable
@@ -333,6 +349,7 @@ jobs:
 
           # Update optional dependencies versions in main package
           sed -i 's/"@codemod\.com\/cli-\([^"]*\)": "0\.0\.0"/"@codemod.com\/cli-\1": "${{ steps.version.outputs.version }}"/g' crates/cli/npm/package.json
+          sed -i 's/"@codemod\.com\/cli-\([^"]*\)": "workspace:0\.0\.0"/"@codemod.com\/cli-\1": "${{ steps.version.outputs.version }}"/g' crates/cli/npm/package.json
 
       - name: Publish platform packages
         run: |

--- a/crates/cli/npm/codemod
+++ b/crates/cli/npm/codemod
@@ -7,8 +7,11 @@ const path = require("path");
 const binaryName = process.platform === "win32" ? "codemod.exe" : "codemod";
 const CODEMOD_BOOTSTRAPPED_ENV = "CODEMOD_BOOTSTRAPPED";
 
-function detectPackageName() {
-  const { platform, arch } = process;
+function detectPackageName({
+  platform = process.platform,
+  arch = process.arch,
+  libcFamily,
+} = {}) {
 
   switch (platform) {
     case "darwin":
@@ -20,9 +23,10 @@ function detectPackageName() {
       }
       break;
     case "linux": {
-      const { family, MUSL } = require("detect-libc");
+      const { familySync, MUSL } = require("detect-libc");
+      const detectedLibcFamily = libcFamily ?? familySync();
       const libcSuffix =
-        family === MUSL ? "musl" : arch === "arm" ? "gnueabihf" : "gnu";
+        detectedLibcFamily === MUSL ? "musl" : arch === "arm" ? "gnueabihf" : "gnu";
       if (arch === "x64") {
         return `@codemod.com/cli-linux-x64-${libcSuffix}`;
       }
@@ -234,6 +238,7 @@ if (require.main === module) {
 
 module.exports = {
   CODEMOD_BOOTSTRAPPED_ENV,
+  detectPackageName,
   latestBootstrapArgs,
   npmExecutable,
   shouldBootstrapLatestNoCommand,

--- a/crates/cli/npm/package.json
+++ b/crates/cli/npm/package.json
@@ -29,7 +29,9 @@
     "@codemod.com/cli-darwin-arm64": "0.0.0",
     "@codemod.com/cli-darwin-x64": "0.0.0",
     "@codemod.com/cli-linux-arm64-gnu": "0.0.0",
+    "@codemod.com/cli-linux-arm64-musl": "workspace:0.0.0",
     "@codemod.com/cli-linux-x64-gnu": "0.0.0",
+    "@codemod.com/cli-linux-x64-musl": "workspace:0.0.0",
     "@codemod.com/cli-win32-x64-msvc": "0.0.0"
   },
   "engines": {

--- a/crates/cli/npm/platforms/linux-arm64-musl/package.json
+++ b/crates/cli/npm/platforms/linux-arm64-musl/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@codemod.com/cli-linux-arm64-musl",
+  "version": "0.0.0",
+  "description": "Codemod platform for semantic code transformations - Linux arm64 musl binary",
+  "keywords": [
+    "ast",
+    "codemod",
+    "migration",
+    "refactoring",
+    "transformation"
+  ],
+  "repository": "https://github.com/codemod/codemod",
+  "license": "Apache-2.0",
+  "files": [
+    "codemod"
+  ],
+  "engines": {
+    "node": ">= 10"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/crates/cli/npm/platforms/linux-x64-musl/package.json
+++ b/crates/cli/npm/platforms/linux-x64-musl/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@codemod.com/cli-linux-x64-musl",
+  "version": "0.0.0",
+  "description": "Codemod platform for semantic code transformations - Linux x64 musl binary",
+  "keywords": [
+    "ast",
+    "codemod",
+    "migration",
+    "refactoring",
+    "transformation"
+  ],
+  "repository": "https://github.com/codemod/codemod",
+  "license": "Apache-2.0",
+  "files": [
+    "codemod"
+  ],
+  "engines": {
+    "node": ">= 10"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/crates/cli/npm/tests/codemod.test.js
+++ b/crates/cli/npm/tests/codemod.test.js
@@ -4,11 +4,27 @@ const { EventEmitter } = require("node:events");
 
 const {
   CODEMOD_BOOTSTRAPPED_ENV,
+  detectPackageName,
   latestBootstrapArgs,
   npmExecutable,
   shouldBootstrapLatestNoCommand,
   run,
 } = require("../codemod");
+
+test("detectPackageName selects the Linux package for the current libc", () => {
+  assert.equal(
+    detectPackageName({ platform: "linux", arch: "x64", libcFamily: "glibc" }),
+    "@codemod.com/cli-linux-x64-gnu",
+  );
+  assert.equal(
+    detectPackageName({ platform: "linux", arch: "x64", libcFamily: "musl" }),
+    "@codemod.com/cli-linux-x64-musl",
+  );
+  assert.equal(
+    detectPackageName({ platform: "linux", arch: "arm64", libcFamily: "musl" }),
+    "@codemod.com/cli-linux-arm64-musl",
+  );
+});
 
 test("shouldBootstrapLatestNoCommand only bootstraps bare invocation", () => {
   assert.equal(shouldBootstrapLatestNoCommand([], {}), true);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,15 @@ importers:
       '@codemod.com/cli-linux-arm64-gnu':
         specifier: 0.0.0
         version: 0.0.0
+      '@codemod.com/cli-linux-arm64-musl':
+        specifier: workspace:0.0.0
+        version: link:platforms/linux-arm64-musl
       '@codemod.com/cli-linux-x64-gnu':
         specifier: 0.0.0
         version: 0.0.0
+      '@codemod.com/cli-linux-x64-musl':
+        specifier: workspace:0.0.0
+        version: link:platforms/linux-x64-musl
       '@codemod.com/cli-win32-x64-msvc':
         specifier: 0.0.0
         version: 0.0.0
@@ -58,7 +64,11 @@ importers:
 
   crates/cli/npm/platforms/linux-arm64-gnu: {}
 
+  crates/cli/npm/platforms/linux-arm64-musl: {}
+
   crates/cli/npm/platforms/linux-x64-gnu: {}
+
+  crates/cli/npm/platforms/linux-x64-musl: {}
 
   crates/cli/npm/platforms/win32-x64-msvc: {}
 


### PR DESCRIPTION
## Summary

- publish x64 and arm64 musl-native CLI packages
- select Linux binaries using synchronous libc detection
- include musl artifacts in GitHub and npm releases

## Why

Production source sync runs `codemod@latest` in an Alpine worker. npm correctly skips the existing glibc-only binaries, leaving the wrapper without a compatible native package.

## Impact

After the next CLI release, Alpine workers can install and run the matching musl binary without changing the worker image.

## Testing

- npm wrapper tests: 6 passed
- repository lint and formatting passed
- frozen pnpm lockfile check passed
- Alpine smoke test selects `@codemod.com/cli-linux-arm64-musl`
- ARM64-musl release-profile `cargo check` passed in Alpine
- release workflow YAML parsed successfully