### PR TITLE
docs: document package dashboard templates for JSSG publishes

### DIFF
--- a/docs/platform/insights.mdx
+++ b/docs/platform/insights.mdx
@@ -178,6 +178,23 @@ Variables can be edited from the dashboard view. Widgets that reference a variab
   Template variables are especially useful for dashboards you reuse across repositories, teams, or migration phases.
 </Tip>
 
+## Dashboard templates
+
+When you publish a package with JSSG steps to the [Codemod Registry](/platform/registry), Codemod attaches a default Insights dashboard template. People who start an Insights dashboard from your package get that template.
+
+You can replace the default with a dashboard you built. If the package is published by an organization, any organization member with developer or admin privileges can update the template.
+
+### Update a package template
+
+<Steps>
+  <Step title="Build a package-backed dashboard">
+    Create or open an Insights dashboard. Add query-backed widgets that use only your published package. For a bundle, widgets can also be powered by the bundle's child packages. You can optionally include Notes widgets.
+  </Step>
+  <Step title="Save it as the package template">
+    When the dashboard looks right, click the three-dot menu next to the dashboard name and select **Update package template**.
+  </Step>
+</Steps>
+
 ## Next steps
 
 <CardGroup cols={2}>

--- a/docs/publishing.mdx
+++ b/docs/publishing.mdx
@@ -436,6 +436,10 @@ jobs:
   <Card title="Tag Releases" icon="tag">
     Use git tags and GitHub releases to trigger publish workflows for clear version history.
   </Card>
+
+  <Card title="Customize Dashboard Templates" icon="chart-simple">
+    Packages with JSSG steps ship a default Insights dashboard. [Update the template](/platform/insights#dashboard-templates) so consumers start from your recommended widgets.
+  </Card>
 </CardGroup>
 
 ## Next Steps

--- a/docs/publishing.mdx
+++ b/docs/publishing.mdx
@@ -438,7 +438,7 @@ jobs:
   </Card>
 
   <Card title="Customize Dashboard Templates" icon="chart-simple">
-    Packages with JSSG steps ship a default Insights dashboard. [Update the template](/platform/insights#dashboard-templates) so consumers start from your recommended widgets.
+    If your package includes JSSG steps, it ships a default Insights dashboard. [Update the dashboard template](/platform/insights#dashboard-templates) so consumers start from your recommended widgets.
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
## Summary
- Add a Best Practices card on the Publishing page for customizing default Insights dashboard templates shipped with JSSG packages
- Add a Dashboard templates section to the Insights docs with permissions and step-by-step update instructions

## Test plan
- [x] Previewed locally with `mint dev` at `/publishing` and `/platform/insights`
- [x] Confirm Best Practices card renders without styling issues
- [x] Confirm link to `/platform/insights#dashboard-templates` works


Made with [Cursor](https://cursor.com)