### PR TITLE
fix: make nested JSSG execution cancellable

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -62,7 +62,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: codemod/codex-review-action@0808e160dab04ad659fdd49cd160a18df4bfd1a8
+      - uses: codemod/codex-review-action@d9f4707c2454897be1c4e93c51c8e69bf0e4ce46
         continue-on-error: ${{ github.actor == 'codemod[bot]' }}
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/codex-review-command.yml
+++ b/.github/workflows/codex-review-command.yml
@@ -80,7 +80,7 @@ jobs:
             }
 
       # The sync workflow replaces @main; pin it manually when copying this template elsewhere.
-      - uses: codemod/codex-review-action@0808e160dab04ad659fdd49cd160a18df4bfd1a8
+      - uses: codemod/codex-review-action@d9f4707c2454897be1c4e93c51c8e69bf0e4ce46
         with:
           github_token: ${{ github.token }}
           pr_number: ${{ needs.resolve-pr.outputs.pr_number }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.23",
  "semantic-factory",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -103,6 +103,9 @@ pub struct InMemoryExecutionOptions<'a, R> {
     pub llm_request_handler: Option<LlmRequestHandler>,
     /// Optional shared state context for cross-thread state communication
     pub shared_state_context: Option<SharedStateContext>,
+    /// Optional cooperative cancellation flag. When set, the QuickJS
+    /// interrupt handler stops execution as soon as cancellation is observed.
+    pub cancellation_flag: Option<Arc<AtomicBool>>,
     /// Execution timeout in milliseconds (default: 200ms)
     pub timeout_ms: Option<u64>,
     /// Memory limit in bytes (default: 64 MB)
@@ -176,15 +179,25 @@ where
 
     let timeout_ms = options.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
     let memory_limit = options.memory_limit.unwrap_or(DEFAULT_MEMORY_LIMIT);
+    let cancellation_flag = options.cancellation_flag.clone();
 
     runtime.set_memory_limit(memory_limit).await;
     runtime.set_max_stack_size(DEFAULT_MAX_STACK_SIZE).await;
     let start_time = Instant::now();
     let timeout_exceeded = Arc::new(AtomicBool::new(false));
     let timeout_exceeded_clone = Arc::clone(&timeout_exceeded);
+    let cancellation_observed = Arc::new(AtomicBool::new(false));
+    let cancellation_observed_clone = Arc::clone(&cancellation_observed);
 
     runtime
         .set_interrupt_handler(Some(Box::new(move || {
+            if cancellation_flag
+                .as_ref()
+                .is_some_and(|flag| flag.load(Ordering::Relaxed))
+            {
+                cancellation_observed_clone.store(true, Ordering::SeqCst);
+                return true;
+            }
             if start_time.elapsed().as_millis() as u64 > timeout_ms {
                 timeout_exceeded_clone.store(true, Ordering::SeqCst);
                 true // Interrupt execution
@@ -259,7 +272,7 @@ where
     let metrics_context = options.metrics_context.clone();
     let llm_runtime_context = LlmRuntimeContext::new(options.llm_request_handler.clone());
     let shared_state_context = options.shared_state_context.clone();
-    let runtime_hooks_context = RuntimeHooksContext::default();
+    let runtime_hooks_context = RuntimeHooksContext::new(None, options.cancellation_flag.clone());
     let process_sandbox = options.process_sandbox.clone();
     let fs_sandbox = options.fs_sandbox.clone();
     let timeout_exceeded_check = Arc::clone(&timeout_exceeded);
@@ -454,6 +467,12 @@ where
     })
     .await;
 
+    if cancellation_observed.load(Ordering::SeqCst) {
+        return Err(ExecutionError::Runtime {
+            source: crate::sandbox::errors::RuntimeError::ExecutionCancelled,
+        });
+    }
+
     if timeout_exceeded_check.load(Ordering::SeqCst) {
         return Err(ExecutionError::Runtime {
             source: crate::sandbox::errors::RuntimeError::ExecutionTimeout { timeout_ms },
@@ -509,6 +528,7 @@ mod tests {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -569,6 +589,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: Some(50), // 50ms timeout for faster test
             memory_limit: None,
             process_sandbox: None,
@@ -587,6 +608,61 @@ export default function transform(root) {
             ),
             Err(e) => panic!("Expected timeout error, got different error: {:?}", e),
         }
+    }
+
+    #[test]
+    fn test_execute_codemod_sync_cancellation_interrupts_quickjs() {
+        let codemod_content = r#"
+export default function transform(root) {
+  while (true) {
+    // Infinite loop to prove cancellation interrupts active JavaScript.
+  }
+  return root.root().text();
+}
+        "#
+        .trim();
+        let content = "const x = 1;";
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        let cancellation_trigger = Arc::clone(&cancellation_flag);
+        let trigger = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            cancellation_trigger.store(true, Ordering::SeqCst);
+        });
+        let started = Instant::now();
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions::<InMemoryResolver> {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast: AstGrep::new(content, js_lang()),
+            original_sha256: Some(compute_sha256(content)),
+            resolver: None,
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: None,
+            target_directory: ".",
+            semantic_provider: None,
+            metrics_context: None,
+            llm_request_handler: None,
+            shared_state_context: None,
+            cancellation_flag: Some(cancellation_flag),
+            timeout_ms: Some(5_000),
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: None,
+        });
+
+        trigger.join().unwrap();
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "cancellation should not wait for the five-second timeout"
+        );
+        assert!(matches!(
+            result,
+            Err(ExecutionError::Runtime {
+                source: RuntimeError::ExecutionCancelled,
+            })
+        ));
     }
 
     #[test]
@@ -630,6 +706,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -779,6 +856,7 @@ export default function transform(root, options) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -854,6 +932,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: Some(sandbox),
@@ -932,6 +1011,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -1009,6 +1089,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -1087,6 +1168,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -1187,6 +1269,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -1554,6 +1637,7 @@ export default function transform(root) {
                 metrics_context: None,
                 llm_request_handler: None,
                 shared_state_context: None,
+                cancellation_flag: None,
                 timeout_ms: None,
                 memory_limit: None,
                 process_sandbox: None,
@@ -1626,6 +1710,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -1735,6 +1820,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -1827,6 +1913,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -1896,6 +1983,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
@@ -1935,6 +2023,7 @@ export default function transform(root) {
             metrics_context: None,
             llm_request_handler: None,
             shared_state_context: None,
+            cancellation_flag: None,
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,

--- a/crates/codemod-sandbox/src/sandbox/errors.rs
+++ b/crates/codemod-sandbox/src/sandbox/errors.rs
@@ -75,6 +75,9 @@ pub enum RuntimeError {
     #[error("Execution timeout: exceeded {timeout_ms}ms limit")]
     ExecutionTimeout { timeout_ms: u64 },
 
+    #[error("Execution cancelled")]
+    ExecutionCancelled,
+
     #[error("Memory limit exceeded")]
     MemoryLimitExceeded,
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -45,6 +45,7 @@ language-core = { workspace = true }
 anyhow.workspace = true
 similar = "2.6.0"
 sha2 = "0.10"
+semver = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/core/src/nested_codemod_service.rs
+++ b/crates/core/src/nested_codemod_service.rs
@@ -1,5 +1,7 @@
 use butterflow_models::{Error, Result, Workflow};
+use futures_util::{stream, StreamExt};
 use log::warn;
+use std::collections::HashSet;
 
 use crate::{
     engine::CodemodDependency,
@@ -15,6 +17,8 @@ pub(crate) struct ResolvedNestedCodemod {
 pub(crate) struct NestedCodemodService<'a> {
     registry_client: &'a RegistryClient,
 }
+
+const PACKAGE_RESOLUTION_CONCURRENCY: usize = 4;
 
 impl<'a> NestedCodemodService<'a> {
     pub(crate) fn new(registry_client: &'a RegistryClient) -> Self {
@@ -84,28 +88,29 @@ impl<'a> NestedCodemodService<'a> {
         workflow: &Workflow,
         dependency_chain: &[CodemodDependency],
     ) -> Result<()> {
-        for node in &workflow.nodes {
-            for step in &node.steps {
-                if let butterflow_models::step::StepAction::Codemod(codemod) = &step.action {
-                    if Self::find_cycle_in_chain(&codemod.source, dependency_chain).is_some() {
-                        return Err(Self::format_cycle_error(
-                            "Codemod dependency cycle detected!",
-                            &codemod.source,
-                            dependency_chain,
-                            "This would cause infinite recursion during execution.",
-                        ));
-                    }
+        let sources = Self::unique_codemod_sources(workflow);
+        for source in &sources {
+            if Self::find_cycle_in_chain(source, dependency_chain).is_some() {
+                return Err(Self::format_cycle_error(
+                    "Codemod dependency cycle detected!",
+                    source,
+                    dependency_chain,
+                    "This would cause infinite recursion during execution.",
+                ));
+            }
+        }
 
-                    if let Err(error) = self
-                        .resolve_and_validate(&codemod.source, dependency_chain)
-                        .await
-                    {
-                        warn!(
-                            "Failed to validate codemod dependency {}: {}",
-                            codemod.source, error
-                        );
-                    }
-                }
+        let validations = stream::iter(sources.into_iter().map(|source| async move {
+            let result = self.resolve_and_validate(&source, dependency_chain).await;
+            (source, result)
+        }))
+        .buffer_unordered(PACKAGE_RESOLUTION_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+
+        for (source, result) in validations {
+            if let Err(error) = result {
+                warn!("Failed to validate codemod dependency {source}: {error}");
             }
         }
 
@@ -117,37 +122,62 @@ impl<'a> NestedCodemodService<'a> {
         workflow: &Workflow,
         dependency_chain: &[CodemodDependency],
     ) -> Result<Option<String>> {
+        let sources = Self::unique_codemod_sources(workflow);
+        let mut resolutions = stream::iter(sources.into_iter().enumerate().map(
+            |(index, source)| async move {
+                let result = self.resolve(&source, dependency_chain).await;
+                (index, source, result)
+            },
+        ))
+        .buffer_unordered(PACKAGE_RESOLUTION_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+        // Preserve workflow order so the reported dry-run-only dependency is
+        // deterministic even though package I/O completes out of order.
+        resolutions.sort_by_key(|(index, _, _)| *index);
+
+        for (_, source, result) in resolutions {
+            let resolved = match result {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    warn!(
+                        "Failed to inspect codemod dependency {source} for dry-run-only status: {error}"
+                    );
+                    continue;
+                }
+            };
+
+            if resolved.package.dry_run_only {
+                return Ok(Some(source));
+            }
+
+            if let Some(source) = Box::pin(
+                self.find_dry_run_only_dependency(&resolved.workflow, &resolved.dependency_chain),
+            )
+            .await?
+            {
+                return Ok(Some(source));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn unique_codemod_sources(workflow: &Workflow) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut sources = Vec::new();
+
         for node in &workflow.nodes {
             for step in &node.steps {
                 if let butterflow_models::step::StepAction::Codemod(codemod) = &step.action {
-                    let resolved = match self.resolve(&codemod.source, dependency_chain).await {
-                        Ok(resolved) => resolved,
-                        Err(error) => {
-                            warn!(
-                                "Failed to inspect codemod dependency {} for dry-run-only status: {}",
-                                codemod.source, error
-                            );
-                            continue;
-                        }
-                    };
-
-                    if resolved.package.dry_run_only {
-                        return Ok(Some(codemod.source.clone()));
-                    }
-
-                    if let Some(source) = Box::pin(self.find_dry_run_only_dependency(
-                        &resolved.workflow,
-                        &resolved.dependency_chain,
-                    ))
-                    .await?
-                    {
-                        return Ok(Some(source));
+                    if seen.insert(codemod.source.clone()) {
+                        sources.push(codemod.source.clone());
                     }
                 }
             }
         }
 
-        Ok(None)
+        sources
     }
 
     async fn resolve_and_validate(
@@ -198,7 +228,15 @@ impl<'a> NestedCodemodService<'a> {
 mod tests {
     use super::*;
     use flate2::{write::GzEncoder, Compression};
-    use std::{collections::HashMap, io::Write, sync::Arc};
+    use std::{
+        collections::HashMap,
+        io::Write,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
     use tokio::net::TcpListener;
 
     #[test]
@@ -301,15 +339,75 @@ mod tests {
         server.abort();
     }
 
+    #[tokio::test]
+    async fn validates_direct_bundle_dependencies_concurrently() {
+        let packages = HashMap::from([
+            (
+                "child-a".to_string(),
+                MockPackage {
+                    workflow: workflow_yaml_without_children(),
+                    dry_run_only: false,
+                },
+            ),
+            (
+                "child-b".to_string(),
+                MockPackage {
+                    workflow: workflow_yaml_without_children(),
+                    dry_run_only: false,
+                },
+            ),
+        ]);
+        let (registry_url, server, metrics) = spawn_registry_server_with_metrics(packages).await;
+        let cache_dir = tempfile::tempdir().expect("cache dir");
+        let registry_client = RegistryClient::new(
+            crate::registry::RegistryConfig {
+                default_registry: registry_url,
+                cache_dir: cache_dir.path().to_path_buf(),
+            },
+            None,
+        );
+        let workflow: Workflow =
+            serde_yaml::from_str(&workflow_yaml_with_children(&["child-a", "child-b"]))
+                .expect("workflow yaml");
+
+        NestedCodemodService::new(&registry_client)
+            .validate_workflow_dependencies(&workflow, &[])
+            .await
+            .expect("dependency validation should succeed");
+
+        assert!(
+            metrics.maximum_active_package_info.load(Ordering::SeqCst) >= 2,
+            "independent child package lookups should overlap"
+        );
+        server.abort();
+    }
+
     #[derive(Clone)]
     struct MockPackage {
         workflow: String,
         dry_run_only: bool,
     }
 
+    #[derive(Default)]
+    struct RegistryServerMetrics {
+        active_package_info: AtomicUsize,
+        maximum_active_package_info: AtomicUsize,
+    }
+
     async fn spawn_registry_server(
         packages: HashMap<String, MockPackage>,
     ) -> (String, tokio::task::JoinHandle<()>) {
+        let (registry_url, handle, _) = spawn_registry_server_with_metrics(packages).await;
+        (registry_url, handle)
+    }
+
+    async fn spawn_registry_server_with_metrics(
+        packages: HashMap<String, MockPackage>,
+    ) -> (
+        String,
+        tokio::task::JoinHandle<()>,
+        Arc<RegistryServerMetrics>,
+    ) {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind test registry");
@@ -317,6 +415,8 @@ mod tests {
         let registry_url = format!("http://{addr}");
         let packages = Arc::new(packages);
         let server_url = registry_url.clone();
+        let metrics = Arc::new(RegistryServerMetrics::default());
+        let server_metrics = Arc::clone(&metrics);
 
         let handle = tokio::spawn(async move {
             loop {
@@ -326,6 +426,7 @@ mod tests {
 
                 let packages = Arc::clone(&packages);
                 let server_url = server_url.clone();
+                let metrics = Arc::clone(&server_metrics);
                 tokio::spawn(async move {
                     let mut buffer = [0; 4096];
                     let Ok(size) = stream
@@ -342,6 +443,18 @@ mod tests {
                     let mut parts = request_line.split_whitespace();
                     let method = parts.next().unwrap_or_default();
                     let path = parts.next().unwrap_or_default();
+
+                    let is_package_info = method == "GET"
+                        && path.starts_with("/api/v1/registry/packages/")
+                        && !path.contains("/download/");
+                    if is_package_info {
+                        let active = metrics.active_package_info.fetch_add(1, Ordering::SeqCst) + 1;
+                        metrics
+                            .maximum_active_package_info
+                            .fetch_max(active, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        metrics.active_package_info.fetch_sub(1, Ordering::SeqCst);
+                    }
 
                     let (status, content_type, body) =
                         registry_response(method, path, &server_url, &packages).unwrap_or_else(
@@ -363,7 +476,7 @@ mod tests {
             }
         });
 
-        (registry_url, handle)
+        (registry_url, handle, metrics)
     }
 
     fn registry_response(

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -127,6 +127,10 @@ struct PackageInfo {
     access: Option<String>,
 }
 
+const PACKAGE_INFO_CACHE_CAPACITY: usize = 256;
+type PackageInfoCacheCell = Arc<tokio::sync::OnceCell<Arc<PackageInfo>>>;
+type PackageInfoCache = Arc<tokio::sync::Mutex<HashMap<String, PackageInfoCacheCell>>>;
+
 #[derive(Deserialize, Debug)]
 #[allow(dead_code)]
 struct PackageVersion {
@@ -174,6 +178,7 @@ pub struct RegistryClient {
     pub auth_provider: Option<Arc<dyn AuthProvider>>,
     client: reqwest::Client,
     package_locks: Arc<tokio::sync::Mutex<HashMap<PathBuf, Weak<tokio::sync::Mutex<()>>>>>,
+    package_info_cache: PackageInfoCache,
 }
 
 pub trait AuthProvider: Send + Sync {
@@ -187,6 +192,7 @@ impl RegistryClient {
             auth_provider,
             client: reqwest::Client::new(),
             package_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            package_info_cache: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -229,7 +235,9 @@ impl RegistryClient {
         );
 
         // Get package information
-        let package_info = self.get_package_info(registry, &package_spec).await?;
+        let package_info = self
+            .get_package_info(registry, &package_spec, !force_download)
+            .await?;
 
         if package_info.is_legacy {
             return Err(RegistryError::LegacyPackage {
@@ -341,6 +349,69 @@ impl RegistryClient {
     }
 
     async fn get_package_info(
+        &self,
+        registry_url: &str,
+        spec: &PackageSpec,
+        use_cache: bool,
+    ) -> Result<Arc<PackageInfo>> {
+        let exact_version = spec
+            .version
+            .as_deref()
+            .filter(|version| semver::Version::parse(version).is_ok());
+
+        if !use_cache || exact_version.is_none() {
+            return self
+                .fetch_package_info(registry_url, spec)
+                .await
+                .map(Arc::new);
+        }
+
+        let cache_key = format!(
+            "{}|{}",
+            registry_url.trim_end_matches('/'),
+            format_package_spec(spec)
+        );
+        let cache_cell = self.package_info_cache_cell(cache_key).await;
+        let package_info = cache_cell
+            .get_or_try_init(|| async {
+                self.fetch_package_info(registry_url, spec)
+                    .await
+                    .map(Arc::new)
+            })
+            .await?;
+
+        Ok(Arc::clone(package_info))
+    }
+
+    async fn package_info_cache_cell(&self, cache_key: String) -> PackageInfoCacheCell {
+        let mut cache = self.package_info_cache.lock().await;
+        if let Some(cell) = cache.get(&cache_key) {
+            return Arc::clone(cell);
+        }
+
+        if cache.len() >= PACKAGE_INFO_CACHE_CAPACITY {
+            let completed_key = cache.iter().find_map(|(key, cell)| {
+                if cell.get().is_some() {
+                    Some(key.clone())
+                } else {
+                    None
+                }
+            });
+            if let Some(completed_key) = completed_key {
+                cache.remove(&completed_key);
+            }
+        }
+
+        let cell = Arc::new(tokio::sync::OnceCell::new());
+        // If every bounded entry is currently being fetched, leave this cell
+        // uncached instead of evicting an in-flight request.
+        if cache.len() < PACKAGE_INFO_CACHE_CAPACITY {
+            cache.insert(cache_key, Arc::clone(&cell));
+        }
+        cell
+    }
+
+    async fn fetch_package_info(
         &self,
         registry_url: &str,
         spec: &PackageSpec,
@@ -1007,6 +1078,159 @@ mod tests {
             "/api/v1/registry/packages/@codemod/canonical-package/download/1.0.0",
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn exact_version_package_info_is_singleflight_and_cached() {
+        let source = "@codemod/example@1.0.0";
+        let info_path = "/api/v1/registry/packages/@codemod/example";
+        let download_path = "/api/v1/registry/packages/@codemod/example/download/1.0.0";
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let (registry_url, server) = spawn_registry_server(
+            info_path.to_string(),
+            package_info_response("example", Some("@codemod")),
+            download_path.to_string(),
+            package_archive(),
+            Arc::clone(&requests),
+        )
+        .await;
+        let cache_dir = tempfile::tempdir().expect("cache dir");
+        let client = RegistryClient::new(
+            RegistryConfig {
+                default_registry: registry_url.clone(),
+                cache_dir: cache_dir.path().to_path_buf(),
+            },
+            None,
+        );
+
+        let (first, second) = tokio::join!(
+            client.resolve_package(source, Some(&registry_url), false, None),
+            client.resolve_package(source, Some(&registry_url), false, None),
+        );
+        first.expect("first resolution");
+        second.expect("concurrent resolution");
+        client
+            .resolve_package(source, Some(&registry_url), false, None)
+            .await
+            .expect("cached resolution");
+
+        let package_info_requests = requests
+            .lock()
+            .expect("requests lock")
+            .iter()
+            .filter(|(method, path)| method == "GET" && path == info_path)
+            .count();
+        assert_eq!(package_info_requests, 1);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn moving_version_package_info_is_not_cached() {
+        let source = "@codemod/example@latest";
+        let info_path = "/api/v1/registry/packages/@codemod/example";
+        let download_path = "/api/v1/registry/packages/@codemod/example/download/1.0.0";
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let (registry_url, server) = spawn_registry_server(
+            info_path.to_string(),
+            package_info_response("example", Some("@codemod")),
+            download_path.to_string(),
+            package_archive(),
+            Arc::clone(&requests),
+        )
+        .await;
+        let cache_dir = tempfile::tempdir().expect("cache dir");
+        let client = RegistryClient::new(
+            RegistryConfig {
+                default_registry: registry_url.clone(),
+                cache_dir: cache_dir.path().to_path_buf(),
+            },
+            None,
+        );
+
+        client
+            .resolve_package(source, Some(&registry_url), false, None)
+            .await
+            .expect("first resolution");
+        client
+            .resolve_package(source, Some(&registry_url), false, None)
+            .await
+            .expect("second resolution");
+
+        let package_info_requests = requests
+            .lock()
+            .expect("requests lock")
+            .iter()
+            .filter(|(method, path)| method == "GET" && path == info_path)
+            .count();
+        assert_eq!(package_info_requests, 2);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn forced_resolutions_bypass_package_info_cache() {
+        let source = "@codemod/example@1.0.0";
+        let info_path = "/api/v1/registry/packages/@codemod/example";
+        let download_path = "/api/v1/registry/packages/@codemod/example/download/1.0.0";
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let (registry_url, server) = spawn_registry_server(
+            info_path.to_string(),
+            package_info_response("example", Some("@codemod")),
+            download_path.to_string(),
+            package_archive(),
+            Arc::clone(&requests),
+        )
+        .await;
+        let cache_dir = tempfile::tempdir().expect("cache dir");
+        let client = RegistryClient::new(
+            RegistryConfig {
+                default_registry: registry_url.clone(),
+                cache_dir: cache_dir.path().to_path_buf(),
+            },
+            None,
+        );
+
+        client
+            .resolve_package(source, Some(&registry_url), true, None)
+            .await
+            .expect("first forced resolution");
+        client
+            .resolve_package(source, Some(&registry_url), true, None)
+            .await
+            .expect("second forced resolution");
+
+        let package_info_requests = requests
+            .lock()
+            .expect("requests lock")
+            .iter()
+            .filter(|(method, path)| method == "GET" && path == info_path)
+            .count();
+        assert_eq!(package_info_requests, 2);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn package_info_cache_stays_bounded() {
+        let cache_dir = tempfile::tempdir().expect("cache dir");
+        let client = RegistryClient::new(
+            RegistryConfig {
+                default_registry: "https://example.com".to_string(),
+                cache_dir: cache_dir.path().to_path_buf(),
+            },
+            None,
+        );
+
+        for index in 0..=PACKAGE_INFO_CACHE_CAPACITY {
+            let cell = client
+                .package_info_cache_cell(format!("package-{index}"))
+                .await;
+            cell.set(Arc::new(package_info_with_dist_tags()))
+                .expect("cache cell should be empty");
+        }
+
+        assert_eq!(
+            client.package_info_cache.lock().await.len(),
+            PACKAGE_INFO_CACHE_CAPACITY
+        );
     }
 
     async fn assert_resolve_package_downloads_from_resolved_path(

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -7,7 +7,7 @@ use serde_json;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use tempfile::TempDir;
 use thiserror::Error;
 use walkdir::WalkDir;
@@ -173,6 +173,7 @@ pub struct RegistryClient {
     pub config: RegistryConfig,
     pub auth_provider: Option<Arc<dyn AuthProvider>>,
     client: reqwest::Client,
+    package_locks: Arc<tokio::sync::Mutex<HashMap<PathBuf, Weak<tokio::sync::Mutex<()>>>>>,
 }
 
 pub trait AuthProvider: Send + Sync {
@@ -185,7 +186,24 @@ impl RegistryClient {
             config,
             auth_provider,
             client: reqwest::Client::new(),
+            package_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
+    }
+
+    async fn package_lock(&self, package_cache_dir: &Path) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self.package_locks.lock().await;
+        // Completed resolutions leave only weak entries behind. Prune them
+        // opportunistically so a long-lived client does not retain every
+        // package path it has ever seen.
+        locks.retain(|_, lock| lock.strong_count() > 0);
+
+        if let Some(lock) = locks.get(package_cache_dir).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        locks.insert(package_cache_dir.to_path_buf(), Arc::downgrade(&lock));
+        lock
     }
 
     pub async fn resolve_package(
@@ -230,6 +248,12 @@ impl RegistryClient {
 
         // Get or create cache directory
         let package_cache_dir = self.get_package_cache_dir(&package_spec, &version)?;
+        // Parallel bundle resolution can discover the same transitive package
+        // through multiple branches. Serialize writes to that package's cache
+        // directory so concurrent downloads cannot remove or partially copy
+        // each other's extracted files.
+        let package_lock = self.package_lock(&package_cache_dir).await;
+        let _package_guard = package_lock.lock().await;
 
         // Check if package is cached and valid.
         let is_pro_package = package_info.access.as_deref() == Some("pro");
@@ -815,6 +839,42 @@ mod tests {
     use std::io::{Cursor, Write};
     use std::sync::Mutex;
     use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn package_locks_are_shared_while_live_and_pruned_after_use() {
+        let cache_dir = tempfile::tempdir().expect("cache dir");
+        let client = RegistryClient::new(
+            RegistryConfig {
+                default_registry: "https://example.invalid".to_string(),
+                cache_dir: cache_dir.path().to_path_buf(),
+            },
+            None,
+        );
+
+        let shared_path = cache_dir.path().join("shared");
+        let first = client.package_lock(&shared_path).await;
+        let second = client.package_lock(&shared_path).await;
+        assert!(Arc::ptr_eq(&first, &second));
+        drop(first);
+        drop(second);
+
+        for index in 0..100 {
+            let lock = client
+                .package_lock(&cache_dir.path().join(format!("package-{index}")))
+                .await;
+            drop(lock);
+        }
+
+        let live = client.package_lock(&cache_dir.path().join("live")).await;
+        let locks = client.package_locks.lock().await;
+        assert_eq!(locks.len(), 1);
+        assert!(locks
+            .get(&cache_dir.path().join("live"))
+            .and_then(Weak::upgrade)
+            .is_some());
+        drop(locks);
+        drop(live);
+    }
 
     #[test]
     fn parse_package_spec_accepts_builder_tag() {


### PR DESCRIPTION
#### 📚 Description

The C# Insights reproduction timed out in the app while LGTM still showed child JSSG work running. This change lets callers stop active QuickJS execution instead of waiting for its timeout.

It also:
- resolves unique nested packages concurrently while keeping workflow validation order;
- reuses pinned package metadata during a run, including concurrent lookups;
- keeps latest, tags, and forced downloads fresh;
- bounds metadata memory to 256 entries and removes unused package locks.

Both Codex review workflows are pinned to the latest network-fix SHA.

#### 🧪 Test Plan

- Infinite-loop JSSG cancellation completes in about 40 ms with a 5 s fallback timeout.
- Local pinned-package reproduction: 3 metadata requests before, 1 after (67% fewer).
- Fresh-lookup tests pass for latest and forced downloads.
- Core library: 132 tests passed.
- Clippy and formatting checks pass.

#### 📄 Documentation to Update

None.