### PR TITLE
Bound JSSG workflow waits

### DIFF
--- a/crates/codemod-sandbox/Cargo.toml
+++ b/crates/codemod-sandbox/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1.0", features = [
   "rt-multi-thread",
   "macros",
   "fs",
+  "time",
 ], optional = true }
 bytes = "1.0"
 dashmap = "6"

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -181,6 +181,7 @@ where
     let memory_limit = options.memory_limit.unwrap_or(DEFAULT_MEMORY_LIMIT);
     let cancellation_flag = options.cancellation_flag.clone();
     let cancellation_wait_flag = options.cancellation_flag.clone();
+    let cancellation_result_flag = options.cancellation_flag.clone();
 
     runtime.set_memory_limit(memory_limit).await;
     runtime.set_max_stack_size(DEFAULT_MAX_STACK_SIZE).await;
@@ -506,6 +507,20 @@ where
         });
     }
 
+    // A workflow state/lock wait observes the same cancellation flag and may
+    // finish by throwing before the polling future wins the select. Preserve
+    // cancellation semantics instead of exposing that host exception as a
+    // generic execution failure.
+    if result.is_err()
+        && cancellation_result_flag
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::Relaxed))
+    {
+        return Err(ExecutionError::Runtime {
+            source: crate::sandbox::errors::RuntimeError::ExecutionCancelled,
+        });
+    }
+
     if timeout_exceeded_check.load(Ordering::SeqCst) {
         return Err(ExecutionError::Runtime {
             source: crate::sandbox::errors::RuntimeError::ExecutionTimeout { timeout_ms },
@@ -781,6 +796,60 @@ export default async function transform() {
 
         trigger.join().unwrap();
         assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(matches!(
+            result,
+            Err(ExecutionError::Runtime {
+                source: RuntimeError::ExecutionCancelled,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_execute_codemod_sync_maps_cancelled_workflow_wait_to_cancellation() {
+        let codemod_content = r#"
+import { getState } from "codemod:workflow";
+
+export default function transform(root) {
+  getState("blocked-state");
+  return root.root().text();
+}
+        "#
+        .trim();
+        let shared_state = SharedStateContext::new();
+        let guard = shared_state.acquire_lock("blocked-state");
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        let execution_cancellation_flag = Arc::clone(&cancellation_flag);
+
+        let runner = std::thread::spawn(move || {
+            let content = "const x = 1;";
+            execute_codemod_sync(InMemoryExecutionOptions::<InMemoryResolver> {
+                codemod_source: codemod_content,
+                language: js_lang(),
+                ast: AstGrep::new(content, js_lang()),
+                original_sha256: Some(compute_sha256(content)),
+                resolver: None,
+                selector_config: None,
+                params: None,
+                matrix_values: None,
+                file_path: None,
+                target_directory: ".",
+                semantic_provider: None,
+                metrics_context: None,
+                llm_request_handler: None,
+                shared_state_context: Some(shared_state),
+                cancellation_flag: Some(execution_cancellation_flag),
+                timeout_ms: Some(5_000),
+                memory_limit: None,
+                process_sandbox: None,
+                fs_sandbox: None,
+            })
+        });
+
+        std::thread::sleep(Duration::from_millis(25));
+        cancellation_flag.store(true, Ordering::SeqCst);
+        let result = runner.join().unwrap();
+        guard.release();
+
         assert!(matches!(
             result,
             Err(ExecutionError::Runtime {

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use vfs::VfsPath;
 
 /// Default execution timeout in milliseconds (180s)
@@ -180,6 +180,7 @@ where
     let timeout_ms = options.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
     let memory_limit = options.memory_limit.unwrap_or(DEFAULT_MEMORY_LIMIT);
     let cancellation_flag = options.cancellation_flag.clone();
+    let cancellation_wait_flag = options.cancellation_flag.clone();
 
     runtime.set_memory_limit(memory_limit).await;
     runtime.set_max_stack_size(DEFAULT_MAX_STACK_SIZE).await;
@@ -277,7 +278,7 @@ where
     let fs_sandbox = options.fs_sandbox.clone();
     let timeout_exceeded_check = Arc::clone(&timeout_exceeded);
 
-    let result = async_with!(context => |ctx| {
+    let execution = async_with!(context => |ctx| {
         // Store metrics context in runtime userdata if provided (must be done inside async_with)
         if let Some(ref metrics_ctx) = metrics_context {
             ctx.store_userdata(metrics_ctx.clone()).map_err(|e| ExecutionError::Runtime {
@@ -464,8 +465,40 @@ where
             )
         };
         execution.await
-    })
-    .await;
+    });
+    let cancellation_wait = async move {
+        match cancellation_wait_flag {
+            Some(flag) => loop {
+                if flag.load(Ordering::Relaxed) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            },
+            None => std::future::pending::<()>().await,
+        }
+    };
+    let remaining_timeout = Duration::from_millis(timeout_ms).saturating_sub(start_time.elapsed());
+
+    // QuickJS invokes the interrupt handler while executing JavaScript, but
+    // an async codemod can instead be parked waiting for a host future. Race
+    // the whole execution against wall-clock timeout and cancellation so
+    // those pending host operations are bounded too.
+    let result = tokio::select! {
+        biased;
+        result = execution => result,
+        _ = cancellation_wait => {
+            cancellation_observed.store(true, Ordering::SeqCst);
+            Err(ExecutionError::Runtime {
+                source: crate::sandbox::errors::RuntimeError::ExecutionCancelled,
+            })
+        }
+        _ = tokio::time::sleep(remaining_timeout) => {
+            timeout_exceeded.store(true, Ordering::SeqCst);
+            Err(ExecutionError::Runtime {
+                source: crate::sandbox::errors::RuntimeError::ExecutionTimeout { timeout_ms },
+            })
+        }
+    };
 
     if cancellation_observed.load(Ordering::SeqCst) {
         return Err(ExecutionError::Runtime {
@@ -611,6 +644,48 @@ export default function transform(root) {
     }
 
     #[test]
+    fn test_execute_codemod_sync_timeout_interrupts_pending_promise() {
+        let codemod_content = r#"
+export default async function transform() {
+  await new Promise(() => {});
+}
+        "#
+        .trim();
+        let content = "const x = 1;";
+        let started = Instant::now();
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions::<InMemoryResolver> {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast: AstGrep::new(content, js_lang()),
+            original_sha256: Some(compute_sha256(content)),
+            resolver: None,
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: None,
+            target_directory: ".",
+            semantic_provider: None,
+            metrics_context: None,
+            llm_request_handler: None,
+            shared_state_context: None,
+            cancellation_flag: None,
+            timeout_ms: Some(50),
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: None,
+        });
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(matches!(
+            result,
+            Err(ExecutionError::Runtime {
+                source: RuntimeError::ExecutionTimeout { timeout_ms: 50 },
+            })
+        ));
+    }
+
+    #[test]
     fn test_execute_codemod_sync_cancellation_interrupts_quickjs() {
         let codemod_content = r#"
 export default function transform(root) {
@@ -657,6 +732,55 @@ export default function transform(root) {
             started.elapsed() < std::time::Duration::from_secs(2),
             "cancellation should not wait for the five-second timeout"
         );
+        assert!(matches!(
+            result,
+            Err(ExecutionError::Runtime {
+                source: RuntimeError::ExecutionCancelled,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_execute_codemod_sync_cancellation_interrupts_pending_promise() {
+        let codemod_content = r#"
+export default async function transform() {
+  await new Promise(() => {});
+}
+        "#
+        .trim();
+        let content = "const x = 1;";
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        let cancellation_trigger = Arc::clone(&cancellation_flag);
+        let trigger = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(25));
+            cancellation_trigger.store(true, Ordering::SeqCst);
+        });
+        let started = Instant::now();
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions::<InMemoryResolver> {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast: AstGrep::new(content, js_lang()),
+            original_sha256: Some(compute_sha256(content)),
+            resolver: None,
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: None,
+            target_directory: ".",
+            semantic_provider: None,
+            metrics_context: None,
+            llm_request_handler: None,
+            shared_state_context: None,
+            cancellation_flag: Some(cancellation_flag),
+            timeout_ms: Some(5_000),
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: None,
+        });
+
+        trigger.join().unwrap();
+        assert!(started.elapsed() < Duration::from_secs(2));
         assert!(matches!(
             result,
             Err(ExecutionError::Runtime {

--- a/crates/codemod-sandbox/src/workflow_global/mod.rs
+++ b/crates/codemod-sandbox/src/workflow_global/mod.rs
@@ -1,10 +1,14 @@
 use crate::ast_grep::serde::JsValue;
+use crate::sandbox::runtime_module::RuntimeHooksContext;
 use dashmap::DashMap;
 use rquickjs::module::{Declarations, Exports, ModuleDef};
 use rquickjs::{prelude::Func, prelude::Opt, Ctx, Exception, Object, Result};
 use std::collections::HashMap;
 use std::env;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, LazyLock, Mutex};
+
+const CANCELLATION_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
 static STEP_OUTPUTS_STORE: LazyLock<Mutex<HashMap<String, HashMap<String, String>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -153,6 +157,18 @@ impl SharedStateContext {
     /// before `f()` runs.  The per-key `Mutex` is held during `f` so that no
     /// `acquireLock` can start between our check and the data operation.
     fn with_key_guard<T>(&self, name: &str, f: impl FnOnce() -> T) -> T {
+        self.with_key_guard_cancellable(name, None, f)
+            .expect("state access without cancellation cannot be cancelled")
+    }
+
+    /// Execute `f` while respecting an active key lock and cooperative
+    /// cancellation. Returns `None` when cancellation wins the wait.
+    fn with_key_guard_cancellable<T>(
+        &self,
+        name: &str,
+        cancellation_flag: Option<&AtomicBool>,
+        f: impl FnOnce() -> T,
+    ) -> Option<T> {
         let lock = self
             .key_locks
             .entry(name.to_string())
@@ -170,13 +186,23 @@ impl SharedStateContext {
             if tid == current {
                 break; // re-entrant: we hold the lock
             }
-            holder = lock.condvar.wait(holder).unwrap();
+            if cancellation_flag.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+                return None;
+            }
+            holder = lock
+                .condvar
+                .wait_timeout(holder, CANCELLATION_POLL_INTERVAL)
+                .unwrap()
+                .0;
+        }
+        if cancellation_flag.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+            return None;
         }
         // holder is either None or current thread — safe to proceed.
         // Keep the MutexGuard alive so no acquireLock can start mid-operation.
         let result = f();
         drop(holder);
-        result
+        Some(result)
     }
 
     pub fn set(&self, name: &str, value: serde_json::Value, persist: bool) {
@@ -200,6 +226,37 @@ impl SharedStateContext {
         });
     }
 
+    fn set_cancellable(
+        &self,
+        name: &str,
+        value: serde_json::Value,
+        persist: bool,
+        cancellation_flag: Option<&AtomicBool>,
+    ) -> Option<()> {
+        self.with_key_guard_cancellable(name, cancellation_flag, || {
+            self.removals.remove(name);
+            self.data
+                .insert(name.to_string(), StateEntry { value, persist });
+        })
+    }
+
+    fn get_cancellable(
+        &self,
+        name: &str,
+        cancellation_flag: Option<&AtomicBool>,
+    ) -> Option<Option<serde_json::Value>> {
+        self.with_key_guard_cancellable(name, cancellation_flag, || {
+            self.data.get(name).map(|entry| entry.value.clone())
+        })
+    }
+
+    fn unset_cancellable(&self, name: &str, cancellation_flag: Option<&AtomicBool>) -> Option<()> {
+        self.with_key_guard_cancellable(name, cancellation_flag, || {
+            self.data.remove(name);
+            self.removals.insert(name.to_string(), ());
+        })
+    }
+
     /// Return all entries where `persist == true`.
     pub fn get_persistable(&self) -> HashMap<String, serde_json::Value> {
         self.data
@@ -221,6 +278,20 @@ impl SharedStateContext {
     ///
     /// Returns an `Arc<SharedLockGuard>` — call `release()` or let it drop.
     pub fn acquire_lock(&self, name: &str) -> Arc<SharedLockGuard> {
+        self.acquire_lock_cancellable(name, None)
+            .expect("lock acquisition without cancellation cannot be cancelled")
+    }
+
+    /// Acquire a named lock while observing cooperative cancellation.
+    ///
+    /// The timed condition-variable wait is not an I/O poll. It only wakes a
+    /// blocked waiter periodically so a cancelled sandbox cannot remain stuck
+    /// behind a workflow that owns the key.
+    pub fn acquire_lock_cancellable(
+        &self,
+        name: &str,
+        cancellation_flag: Option<&AtomicBool>,
+    ) -> Option<Arc<SharedLockGuard>> {
         let key_lock = self
             .key_locks
             .entry(name.to_string())
@@ -239,20 +310,30 @@ impl SharedStateContext {
                 // Re-entrant: same thread already holds this lock.
                 // This is a programming error — return a no-op guard rather than deadlocking.
                 drop(holder);
-                return Arc::new(SharedLockGuard {
+                return Some(Arc::new(SharedLockGuard {
                     key_lock,
                     released: std::sync::atomic::AtomicBool::new(true), // already "released" — won't double-release
-                });
+                }));
             }
-            holder = key_lock.condvar.wait(holder).unwrap();
+            if cancellation_flag.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+                return None;
+            }
+            holder = key_lock
+                .condvar
+                .wait_timeout(holder, CANCELLATION_POLL_INTERVAL)
+                .unwrap()
+                .0;
+        }
+        if cancellation_flag.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+            return None;
         }
         *holder = Some(current);
         drop(holder);
 
-        Arc::new(SharedLockGuard {
+        Some(Arc::new(SharedLockGuard {
             key_lock,
             released: std::sync::atomic::AtomicBool::new(false),
-        })
+        }))
     }
 }
 
@@ -291,7 +372,17 @@ fn set_state_rjs(ctx: Ctx<'_>, name: String, value: JsValue, persist: Opt<bool>)
         Exception::throw_message(&ctx, "SharedStateContext not found in runtime userdata")
     })?;
     let persist = persist.0.unwrap_or(true);
-    shared_state.set(&name, value.0, persist);
+    let runtime_hooks = ctx.userdata::<RuntimeHooksContext>().ok_or_else(|| {
+        Exception::throw_message(&ctx, "RuntimeHooksContext not found in runtime userdata")
+    })?;
+    shared_state
+        .set_cancellable(
+            &name,
+            value.0,
+            persist,
+            runtime_hooks.cancellation_flag.as_deref(),
+        )
+        .ok_or_else(|| Exception::throw_message(&ctx, "Workflow state update cancelled"))?;
     Ok(())
 }
 
@@ -300,7 +391,12 @@ fn get_state_rjs<'js>(ctx: Ctx<'js>, name: String) -> Result<rquickjs::Value<'js
         let shared_state = ctx.userdata::<SharedStateContext>().ok_or_else(|| {
             Exception::throw_message(&ctx, "SharedStateContext not found in runtime userdata")
         })?;
-        shared_state.get(&name)
+        let runtime_hooks = ctx.userdata::<RuntimeHooksContext>().ok_or_else(|| {
+            Exception::throw_message(&ctx, "RuntimeHooksContext not found in runtime userdata")
+        })?;
+        shared_state
+            .get_cancellable(&name, runtime_hooks.cancellation_flag.as_deref())
+            .ok_or_else(|| Exception::throw_message(&ctx, "Workflow state read cancelled"))?
     };
     match value {
         Some(val) => JsValue(val).into_js(&ctx),
@@ -312,7 +408,12 @@ fn unset_state_rjs(ctx: Ctx<'_>, name: String) -> Result<()> {
     let shared_state = ctx.userdata::<SharedStateContext>().ok_or_else(|| {
         Exception::throw_message(&ctx, "SharedStateContext not found in runtime userdata")
     })?;
-    shared_state.unset(&name);
+    let runtime_hooks = ctx.userdata::<RuntimeHooksContext>().ok_or_else(|| {
+        Exception::throw_message(&ctx, "RuntimeHooksContext not found in runtime userdata")
+    })?;
+    shared_state
+        .unset_cancellable(&name, runtime_hooks.cancellation_flag.as_deref())
+        .ok_or_else(|| Exception::throw_message(&ctx, "Workflow state removal cancelled"))?;
     Ok(())
 }
 
@@ -321,7 +422,12 @@ fn acquire_lock_rjs<'js>(ctx: Ctx<'js>, name: String) -> Result<rquickjs::Functi
         let shared_state = ctx.userdata::<SharedStateContext>().ok_or_else(|| {
             Exception::throw_message(&ctx, "SharedStateContext not found in runtime userdata")
         })?;
-        shared_state.acquire_lock(&name)
+        let runtime_hooks = ctx.userdata::<RuntimeHooksContext>().ok_or_else(|| {
+            Exception::throw_message(&ctx, "RuntimeHooksContext not found in runtime userdata")
+        })?;
+        shared_state
+            .acquire_lock_cancellable(&name, runtime_hooks.cancellation_flag.as_deref())
+            .ok_or_else(|| Exception::throw_message(&ctx, "Workflow lock acquisition cancelled"))?
     };
 
     // Return a one-shot release function.
@@ -727,6 +833,55 @@ mod tests {
         }
 
         assert_eq!(counter.load(Ordering::SeqCst), 5);
+    }
+
+    #[test]
+    fn test_shared_state_lock_wait_observes_cancellation() {
+        let ctx = SharedStateContext::new();
+        let guard = ctx.acquire_lock("cancelled-lock");
+        let waiting_ctx = ctx.clone();
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        let waiting_cancellation_flag = Arc::clone(&cancellation_flag);
+
+        let waiter = thread::spawn(move || {
+            let started = std::time::Instant::now();
+            let acquired = waiting_ctx
+                .acquire_lock_cancellable("cancelled-lock", Some(&waiting_cancellation_flag));
+            (acquired, started.elapsed())
+        });
+
+        thread::sleep(std::time::Duration::from_millis(10));
+        cancellation_flag.store(true, Ordering::SeqCst);
+
+        let (acquired, elapsed) = waiter.join().unwrap();
+        assert!(acquired.is_none());
+        assert!(elapsed < std::time::Duration::from_millis(250));
+        guard.release();
+    }
+
+    #[test]
+    fn test_shared_state_access_wait_observes_cancellation() {
+        let ctx = SharedStateContext::new();
+        ctx.set("cancelled-state", serde_json::json!(1), true);
+        let guard = ctx.acquire_lock("cancelled-state");
+        let waiting_ctx = ctx.clone();
+        let cancellation_flag = Arc::new(AtomicBool::new(false));
+        let waiting_cancellation_flag = Arc::clone(&cancellation_flag);
+
+        let waiter = thread::spawn(move || {
+            let started = std::time::Instant::now();
+            let value =
+                waiting_ctx.get_cancellable("cancelled-state", Some(&waiting_cancellation_flag));
+            (value, started.elapsed())
+        });
+
+        thread::sleep(std::time::Duration::from_millis(10));
+        cancellation_flag.store(true, Ordering::SeqCst);
+
+        let (value, elapsed) = waiter.join().unwrap();
+        assert!(value.is_none());
+        assert!(elapsed < std::time::Duration::from_millis(250));
+        guard.release();
     }
 
     #[test]

--- a/crates/codemod-sandbox/src/workflow_global/mod.rs
+++ b/crates/codemod-sandbox/src/workflow_global/mod.rs
@@ -186,14 +186,18 @@ impl SharedStateContext {
             if tid == current {
                 break; // re-entrant: we hold the lock
             }
-            if cancellation_flag.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
-                return None;
-            }
-            holder = lock
-                .condvar
-                .wait_timeout(holder, CANCELLATION_POLL_INTERVAL)
-                .unwrap()
-                .0;
+            holder = match cancellation_flag {
+                Some(flag) => {
+                    if flag.load(Ordering::Relaxed) {
+                        return None;
+                    }
+                    lock.condvar
+                        .wait_timeout(holder, CANCELLATION_POLL_INTERVAL)
+                        .unwrap()
+                        .0
+                }
+                None => lock.condvar.wait(holder).unwrap(),
+            };
         }
         if cancellation_flag.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
             return None;
@@ -315,14 +319,19 @@ impl SharedStateContext {
                     released: std::sync::atomic::AtomicBool::new(true), // already "released" — won't double-release
                 }));
             }
-            if cancellation_flag.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
-                return None;
-            }
-            holder = key_lock
-                .condvar
-                .wait_timeout(holder, CANCELLATION_POLL_INTERVAL)
-                .unwrap()
-                .0;
+            holder = match cancellation_flag {
+                Some(flag) => {
+                    if flag.load(Ordering::Relaxed) {
+                        return None;
+                    }
+                    key_lock
+                        .condvar
+                        .wait_timeout(holder, CANCELLATION_POLL_INTERVAL)
+                        .unwrap()
+                        .0
+                }
+                None => key_lock.condvar.wait(holder).unwrap(),
+            };
         }
         if cancellation_flag.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
             return None;


### PR DESCRIPTION
## Summary

- Stop async codemods when their timeout or cancellation signal is reached, including while they are waiting on a host promise.
- Make workflow lock and state waits observe cancellation.

## Why

In the 3,614-file nopCommerce-2 reproduction, a workflow could remain active after the 25-second limit because QuickJS was waiting on a host operation. The query stayed active for more than 64 seconds and used about 4.8 GiB.

Combined with codemod/pg_ast_grep#19, the release-mode reproduction finished in 11.8 seconds with zero errors and the same 6 flagged files. A forced timeout stopped all workers about 172 ms after cancellation.

## Tests

- 5 cancellation tests passed.
- 2 timeout tests passed.
- The pending-promise and blocked workflow-state cases are covered.